### PR TITLE
Win32 dynamic library fixes

### DIFF
--- a/src/adf_dump.c
+++ b/src/adf_dump.c
@@ -34,6 +34,7 @@
 #include"adf_disk.h"
 #include"adf_nativ.h"
 #include"adf_err.h"
+#include"adf_dump.h"
 
 extern struct Env adfEnv;
 

--- a/src/adf_dump.h
+++ b/src/adf_dump.h
@@ -32,7 +32,7 @@ PREFIX RETCODE adfCreateHdFile(struct Device* dev, char* volName, int volType);
 BOOL adfInitDumpDevice(struct Device* dev, char* name,BOOL);
 BOOL adfReadDumpSector(struct Device *dev, int32_t n, int size, uint8_t* buf);
 BOOL adfWriteDumpSector(struct Device *dev, int32_t n, int size, uint8_t* buf);
-void adfReleaseDumpDevice(struct Device *dev);
+RETCODE adfReleaseDumpDevice(struct Device *dev);
 
 
 #endif /* ADF_DUMP_H */

--- a/src/win32/adf_nativ.h
+++ b/src/win32/adf_nativ.h
@@ -20,7 +20,6 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  */
- */
 
 #ifndef ADF_NATIV_H
 #define ADF_NATIV_H


### PR DESCRIPTION
Win32 dynamic library was not working.
Syntax error in adf_nativ.h
Unprefixed api method in adf_dump.c (therefore not exported from dll)
Prototype discrepancy in adfReleaseDumpDevice method