### PR TITLE
Fix for calculating bootblock sum on 64-bit system

### DIFF
--- a/src/adf_raw.c
+++ b/src/adf_raw.c
@@ -303,7 +303,7 @@ adfBootSum(uint8_t *buf)
     for(i=0; i<256; i++) {
         if (i!=1) {
             d = Long(buf+i*4);
-            if ( (ULONG_MAX-newSum)<d )
+            if ( (0xffffffffU-newSum)<d )
                 newSum++;
             newSum+=d;
         }


### PR DESCRIPTION
The issue that the code uses ULONG_MAX which on a 64-bit system is a 64-bit value which makes the code to calculate an invalid checksum for the bootblock so the floppy disk will not boot correctly.

More info can be found about this in this issue https://github.com/lclevy/ADFlib/issues/3