### PR TITLE
Build fixes

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
-libtoolize --copy --force
+
+# Some hosts (Mac homebrew) installs a modern libtoolize as 'glibtoolize'.
+# Allow `LIBTOOLIZE' to be set in the environment to allow this.
+if [ "x$LIBTOOLIZE" == "x" ]; then
+  LIBTOOLIZE=libtoolize
+fi
+$LIBTOOLIZE --copy --force
+
 aclocal
 autoconf
 autoheader

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = unadf
 unadf_SOURCES = unadf.c
-unadf_LDADD = $(top_srcdir)/src/libadf.la
-unadf_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+unadf_LDADD = $(top_builddir)/src/libadf.la
+unadf_DEPENDENCIES = $(top_builddir)/src/libadf.la
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/$(NATIVE_DIR)
 

--- a/regtests/Test/Makefile.am
+++ b/regtests/Test/Makefile.am
@@ -5,98 +5,98 @@ bin_PROGRAMS =fl_test fl_test2 dir_test dir_test2 hd_test hd_test2 hd_test3 \
 	undel2 dispsect progbar undel3
 
 fl_test_SOURCES = fl_test.c
-fl_test_LDADD = $(top_srcdir)/src/libadf.la
-fl_test_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+fl_test_LDADD = $(top_builddir)/src/libadf.la
+fl_test_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 fl_test2_SOURCES = fl_test2.c
-fl_test2_LDADD = $(top_srcdir)/src/libadf.la
-fl_test2_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+fl_test2_LDADD = $(top_builddir)/src/libadf.la
+fl_test2_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 dir_test_SOURCES = dir_test.c
-dir_test_LDADD = $(top_srcdir)/src/libadf.la
-dir_test_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+dir_test_LDADD = $(top_builddir)/src/libadf.la
+dir_test_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 dir_test2_SOURCES = dir_test2.c
-dir_test2_LDADD = $(top_srcdir)/src/libadf.la
-dir_test2_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+dir_test2_LDADD = $(top_builddir)/src/libadf.la
+dir_test2_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 hd_test_SOURCES = hd_test.c
-hd_test_LDADD = $(top_srcdir)/src/libadf.la
-hd_test_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+hd_test_LDADD = $(top_builddir)/src/libadf.la
+hd_test_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 hd_test2_SOURCES = hd_test2.c
-hd_test2_LDADD = $(top_srcdir)/src/libadf.la
-hd_test2_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+hd_test2_LDADD = $(top_builddir)/src/libadf.la
+hd_test2_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 hd_test3_SOURCES = hd_test3.c
-hd_test3_LDADD = $(top_srcdir)/src/libadf.la
-hd_test3_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+hd_test3_LDADD = $(top_builddir)/src/libadf.la
+hd_test3_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 file_test_SOURCES = file_test.c
-file_test_LDADD = $(top_srcdir)/src/libadf.la
-file_test_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+file_test_LDADD = $(top_builddir)/src/libadf.la
+file_test_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 file_test2_SOURCES = file_test2.c
-file_test2_LDADD = $(top_srcdir)/src/libadf.la
-file_test2_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+file_test2_LDADD = $(top_builddir)/src/libadf.la
+file_test2_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 file_test3_SOURCES = file_test3.c
-file_test3_LDADD = $(top_srcdir)/src/libadf.la
-file_test3_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+file_test3_LDADD = $(top_builddir)/src/libadf.la
+file_test3_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 del_test_SOURCES = del_test.c
-del_test_LDADD = $(top_srcdir)/src/libadf.la
-del_test_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+del_test_LDADD = $(top_builddir)/src/libadf.la
+del_test_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 bootdisk_SOURCES = bootdisk.c
-bootdisk_LDADD = $(top_srcdir)/src/libadf.la
-bootdisk_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+bootdisk_LDADD = $(top_builddir)/src/libadf.la
+bootdisk_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 rename_SOURCES = rename.c
-rename_LDADD = $(top_srcdir)/src/libadf.la
-rename_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+rename_LDADD = $(top_builddir)/src/libadf.la
+rename_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 hardfile_SOURCES = hardfile.c
-hardfile_LDADD = $(top_srcdir)/src/libadf.la
-hardfile_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+hardfile_LDADD = $(top_builddir)/src/libadf.la
+hardfile_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 rename2_SOURCES = rename2.c
-rename2_LDADD = $(top_srcdir)/src/libadf.la
-rename2_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+rename2_LDADD = $(top_builddir)/src/libadf.la
+rename2_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 hardfile2_SOURCES = hardfile2.c
-hardfile2_LDADD = $(top_srcdir)/src/libadf.la
-hardfile2_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+hardfile2_LDADD = $(top_builddir)/src/libadf.la
+hardfile2_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 access_SOURCES = access.c
-access_LDADD = $(top_srcdir)/src/libadf.la
-access_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+access_LDADD = $(top_builddir)/src/libadf.la
+access_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 comment_SOURCES = comment.c
-comment_LDADD = $(top_srcdir)/src/libadf.la
-comment_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+comment_LDADD = $(top_builddir)/src/libadf.la
+comment_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 undel_SOURCES = undel.c
-undel_LDADD = $(top_srcdir)/src/libadf.la
-undel_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+undel_LDADD = $(top_builddir)/src/libadf.la
+undel_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 readonly_SOURCES = readonly.c
-readonly_LDADD = $(top_srcdir)/src/libadf.la
-readonly_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+readonly_LDADD = $(top_builddir)/src/libadf.la
+readonly_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 undel2_SOURCES = undel2.c
-undel2_LDADD = $(top_srcdir)/src/libadf.la
-undel2_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+undel2_LDADD = $(top_builddir)/src/libadf.la
+undel2_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 dispsect_SOURCES = dispsect.c
-dispsect_LDADD = $(top_srcdir)/src/libadf.la
-dispsect_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+dispsect_LDADD = $(top_builddir)/src/libadf.la
+dispsect_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 progbar_SOURCES = progbar.c
-progbar_LDADD = $(top_srcdir)/src/libadf.la
-progbar_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+progbar_LDADD = $(top_builddir)/src/libadf.la
+progbar_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 undel3_SOURCES = undel3.c
-undel3_LDADD = $(top_srcdir)/src/libadf.la
-undel3_DEPENDENCIES = $(top_srcdir)/src/libadf.la
+undel3_LDADD = $(top_builddir)/src/libadf.la
+undel3_DEPENDENCIES = $(top_builddir)/src/libadf.la
 


### PR DESCRIPTION
These changes make it so you can:

* Build the library from an out of source directory
* Override the `libtoolize` command via an environment variable, to support building on Macs with a homebrew installed libtool