### PR TITLE
Fix warning with modern glibc versions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,6 +39,6 @@ include_HEADERS = adf_defs.h \
                   $(NATIVE_DIR)/adf_nativ.h
 
 libadf_la_LDFLAGS = -version-info 0:12:0
-AM_CPPFLAGS = -D_XOPEN_SOURCE -D_SVID_SOURCE -D_BSD_SOURCE -D_GNU_SOURCE -I$(srcdir) -I$(srcdir)/$(NATIVE_DIR)
+AM_CPPFLAGS = -D_XOPEN_SOURCE -D_SVID_SOURCE -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_GNU_SOURCE -I$(srcdir) -I$(srcdir)/$(NATIVE_DIR)
 AM_CFLAGS = -std=c99 -pedantic -Wall
 


### PR DESCRIPTION
Defining _SVID_SOURCE or _BSD_SOURCE has been deprecated in modern glibc
versions and doing so will produce a warning:

  /usr/include/features.h: warning:
  #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"

Normally, these should be replaced with _DEFAULT_SOURCE, but for backwards
compatibility, the warning is not emitted when _DEFAULT_SOURCE is defined in
addition to the deprecated macros, so the pattern these days is to define all
three macros.