### PR TITLE
Fixed setting EOF status after seek (default method using ext. blocks) + test

### DIFF
--- a/src/adf_file.c
+++ b/src/adf_file.c
@@ -315,6 +315,8 @@ static RETCODE adfFileSeekExt ( struct File * file,
                        file->curDataPtr,
                        file->currentData );
 
+    file->eof = ( file->pos == file->fileHdr->byteSize );
+
     return RC_OK;
 }
 


### PR DESCRIPTION
One line was missing in `adfFileSeekExt()`. I added also a simple test.

(this is still concerning lclevy/ADFlib#19)