### PR TITLE
Support for readling hard-linked files

### DIFF
--- a/regtests/Test/CMakeLists.txt
+++ b/regtests/Test/CMakeLists.txt
@@ -47,6 +47,9 @@ TARGET_LINK_LIBRARIES ( file_seek_test adf )
 add_executable ( file_seek_test2 file_seek_test2.c )
 TARGET_LINK_LIBRARIES ( file_seek_test2 adf )
 
+add_executable ( file_read_hard_link_test file_read_hard_link_test.c )
+TARGET_LINK_LIBRARIES ( file_read_hard_link_test adf )
+
 add_executable ( del_test del_test.c )
 TARGET_LINK_LIBRARIES ( del_test adf )
 

--- a/regtests/Test/Makefile.am
+++ b/regtests/Test/Makefile.am
@@ -1,7 +1,7 @@
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/$(NATIVE_DIR)
 bin_PROGRAMS =fl_test fl_test2 dir_test dir_test2 hd_test hd_test2 hd_test3 \
         file_test file_test2 file_test3 file_seek_test file_seek_test2 \
-        del_test bootdisk \
+        file_read_hard_link_test del_test bootdisk \
         rename hardfile rename2 hardfile2 access comment undel readonly \
 	undel2 dispsect progbar undel3
 
@@ -52,6 +52,10 @@ file_seek_test_DEPENDENCIES = $(top_builddir)/src/libadf.la
 file_seek_test2_SOURCES = file_seek_test2.c
 file_seek_test2_LDADD = $(top_builddir)/src/libadf.la
 file_seek_test2_DEPENDENCIES = $(top_builddir)/src/libadf.la
+
+file_read_hard_link_test_SOURCES = file_read_hard_link_test.c
+file_read_hard_link_test_LDADD = $(top_builddir)/src/libadf.la
+file_read_hard_link_test_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
 del_test_SOURCES = del_test.c
 del_test_LDADD = $(top_builddir)/src/libadf.la

--- a/regtests/Test/file_read_hard_link_test.c
+++ b/regtests/Test/file_read_hard_link_test.c
@@ -1,0 +1,145 @@
+/*
+ * file_seek_test2.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include"adflib.h"
+
+
+typedef struct check_s {
+    unsigned int  offset;
+    unsigned char value;
+} check_t;
+
+typedef struct reading_test_s {
+    char *       image_filename;
+    char *       hlink_name;
+    char *       file_name;
+
+    unsigned int nchecks;
+    check_t      checks[];
+} reading_test_t;
+
+
+reading_test_t test_hlink = {
+    .hlink_name = "hlink_blue",
+    .file_name  = "dir_2/blue2c.gif",
+    .nchecks    = 8,
+    .checks     = {
+        { 0, 0x47 },
+        { 1, 0x49 },
+        { 2, 0x46 },
+        { 3, 0x38 },
+                    
+        // the last 4 bytes of the file
+        { 0xcfe, 0x42 },
+        { 0xcff, 0x04 },
+        { 0xd00, 0x00 },
+        { 0xd01, 0x3B }
+    }
+};
+
+
+int test_simple_hlink_read ( struct Volume * const vol,
+                             reading_test_t * test_data );
+
+int test_single_read ( struct File * const file_adf,
+                       unsigned int        offset,
+                       unsigned char       expected_value );
+
+
+int main ( int argc, char * argv[] )
+{ 
+    adfEnvInitDefault();
+
+//	adfSetEnvFct(0,0,MyVer,0);
+    int status = 0;
+
+    // setup
+    test_hlink.image_filename = argv[1];
+
+    struct Device * const dev = adfMountDev ( test_hlink.image_filename, TRUE );
+    if ( ! dev ) {
+        printf ( "Cannot mount image %s - aborting the test...\n",
+                 test_hlink.image_filename );
+        return 1;
+    }
+
+    struct Volume * const vol = adfMount ( dev, 0, TRUE );
+    if ( ! vol ) {
+        printf ( "Cannot mount volume 0 from image %s - aborting the test...\n",
+                 test_hlink.image_filename );
+        adfUnMountDev ( dev );
+        return 1;
+    }
+    //adfVolumeInfo ( vol );    
+
+    // run tests
+    status += test_simple_hlink_read ( vol, &test_hlink );
+
+    // clean-up
+    adfUnMount ( vol );
+    adfUnMountDev ( dev );
+    
+    adfEnvCleanUp();
+
+    return status;
+}
+
+
+int test_simple_hlink_read ( struct Volume * const vol,
+                             reading_test_t * test_data )
+{
+    printf ( "\n*** Testing single hard link file reads"
+             "\n\timage file:\t%s\n\thlink:\t%s\n\treal file:\t%s\n",
+             test_data->image_filename,
+             test_data->hlink_name,
+             test_data->file_name );
+
+    int status = 0;
+    struct File * const file_adf = adfOpenFile ( vol, test_data->hlink_name, "r" );
+    if ( ! file_adf ) {
+        fprintf ( stderr, "Cannot open hard link file %s - aborting...\n",
+                  test_data->hlink_name );
+        return 1;
+    }
+
+    for ( int i = 0 ; i < test_data->nchecks ; ++i ) {
+        status += test_single_read ( file_adf,
+                                     test_data->checks[i].offset,
+                                     test_data->checks[i].value );
+    }
+
+    adfCloseFile ( file_adf );
+
+    return status;
+}
+
+
+int test_single_read ( struct File * const file_adf,
+                       unsigned int        offset,
+                       unsigned char       expected_value )
+{
+    printf ( "  Reading data after seek to position 0x%x (%d)...",
+             offset, offset );
+
+    adfFileSeek ( file_adf, offset );
+
+    unsigned char c;
+    int n = adfReadFile ( file_adf, 1, &c );
+
+    if ( n != 1 ) {
+        printf ( " -> Reading data failed!!!\n" );
+        return 1;
+    }
+    
+    if ( c != expected_value ) {
+        printf ( " -> Incorrect data read:  expected 0x%x != read 0x%x\n",
+                 (int) expected_value, (int) c );
+        return 1;
+    }
+
+    printf ( " -> OK.\n" );
+    return 0;
+}

--- a/regtests/Test/floppy.sh
+++ b/regtests/Test/floppy.sh
@@ -73,6 +73,12 @@ file_seek_test2 testofs_adf testffs_adf
 rm testofs_adf testffs_adf
 echo "-----"
 
+echo "Executing file_read_hard_link_test..."
+cp $FFSDUMP testffs_adf
+file_read_hard_link_test testffs_adf
+rm testffs_adf
+echo "-----"
+
 
 rename
 rm newdev

--- a/src/adf_file.c
+++ b/src/adf_file.c
@@ -369,6 +369,15 @@ struct File* adfOpenFile(struct Volume *vol, char* name, char *mode)
 */    if (write && nSect!=-1) {
         (*adfEnv.wFct)("adfFileOpen : file already exists"); return NULL; }  
 
+    // if current entry is a hard-link - load entry of the hard-linked file
+    if ( entry.realEntry )  {
+        adfReadEntryBlock ( vol, entry.realEntry, &entry );
+        adfReadEntryBlock ( vol, entry.parent, &parent );
+    }
+    if ( entry.realEntry != 0 ) {   // entry should be a real file now
+        return NULL;                //... so if it is still a (hard)link - error...
+    }
+
     file = (struct File*)malloc(sizeof(struct File));
     if (!file) { (*adfEnv.wFct)("adfFileOpen : malloc"); return NULL; }
     file->fileHdr = (struct bFileHeaderBlock*)malloc(sizeof(struct bFileHeaderBlock));


### PR DESCRIPTION
As mentioned in lclevy/ADFlib#23, here is the small modification for `adfOpenFile()` which adds support for opening files using their hard links (+ a small test).