### PR TITLE
Added a test and a bugfix for the issue with overfilling floppy image

### DIFF
--- a/regtests/Test/CMakeLists.txt
+++ b/regtests/Test/CMakeLists.txt
@@ -92,6 +92,9 @@ TARGET_LINK_LIBRARIES ( progbar adf )
 add_executable ( undel3 undel3.c )
 TARGET_LINK_LIBRARIES ( undel3 adf )
 
+add_executable ( floppy_overfilling_test floppy_overfilling_test.c )
+TARGET_LINK_LIBRARIES ( floppy_overfilling_test adf )
+
 configure_file(floppy.sh floppy.sh COPYONLY)
 configure_file(bigdev.sh bigdev.sh COPYONLY)
 

--- a/regtests/Test/Makefile.am
+++ b/regtests/Test/Makefile.am
@@ -3,7 +3,7 @@ bin_PROGRAMS = fl_test fl_test2 dir_test dir_test2 dir_test_chdir hd_test \
         hd_test2 hd_test3 file_test file_test2 file_test3 file_seek_test \
         file_seek_test2 file_read_hard_link_test del_test bootdisk \
         rename hardfile rename2 hardfile2 access comment undel readonly \
-	undel2 dispsect progbar undel3
+	undel2 dispsect progbar undel3 floppy_overfilling_test
 
 fl_test_SOURCES = fl_test.c
 fl_test_LDADD = $(top_builddir)/src/libadf.la
@@ -117,3 +117,6 @@ undel3_SOURCES = undel3.c
 undel3_LDADD = $(top_builddir)/src/libadf.la
 undel3_DEPENDENCIES = $(top_builddir)/src/libadf.la
 
+floppy_overfilling_test_SOURCES = floppy_overfilling_test.c
+floppy_overfilling_test_LDADD = $(top_builddir)/src/libadf.la
+floppy_overfilling_test_DEPENDENCIES = $(top_builddir)/src/libadf.la

--- a/regtests/Test/floppy.sh
+++ b/regtests/Test/floppy.sh
@@ -112,3 +112,9 @@ undel3 testofs_adf
 #diff moon_gif $CHECK/MOON.GIF
 rm moon_gif testofs_adf
 echo "-----"
+
+
+echo "Running over-filling test..."
+floppy_overfilling_test
+rm test.adf
+echo "-----"

--- a/regtests/Test/floppy_overfilling_test.c
+++ b/regtests/Test/floppy_overfilling_test.c
@@ -1,0 +1,94 @@
+
+//
+// regr. test for the issue:
+//   https://github.com/lclevy/ADFlib/issues/9
+//
+
+#include "adflib.h"
+
+#define TEST_VERBOSITY 1
+
+int test_floppy_overfilling ( char * const          adfname,
+                              char * const          filename,
+                              unsigned char * const buffer,
+                              const int             blocksize );
+
+int main (void)
+{
+    adfEnvInitDefault();
+
+    const int BUF_SIZE = 4096;
+    unsigned char buf [ BUF_SIZE ];
+    for ( int i = 0 ; i < BUF_SIZE ; i += 4 ) {
+        buf[i]   = 'A';
+        buf[i+1] = 'M';
+        buf[i+2] = 'I';
+        buf[i+3] = 'G';
+    }
+
+    int status = 0;
+
+    int test_bufsize[] = { 4096, 4095, 2049, 2048, 1025, 1024, 1023,
+        513, 512, 511, 257, 256, 128, 32, 16, 8, 4, 2, 1 };
+
+    for ( unsigned i = 0 ; i < sizeof ( test_bufsize ) / sizeof ( int ) ; ++i ) {
+        status += test_floppy_overfilling (
+            "test.adf", "testfile1.dat", buf, test_bufsize[i] );
+    }
+
+    adfEnvCleanUp();
+    return status;
+}
+
+
+int test_floppy_overfilling ( char * const          adfname,
+                              char * const          filename,
+                              unsigned char * const buffer,
+                              const int             blocksize )
+{
+#if TEST_VERBOSITY > 0
+    printf ("Test floppy overfilling, blocksize: %d", blocksize );
+#endif
+
+    struct Device * device = adfCreateDumpDevice ( adfname, 80, 2, 11 );
+    if ( ! device )
+        return 1;
+    adfCreateFlop ( device, "Floppy2ADF", 0 );
+
+    struct Volume * vol = adfMount ( device, 0, FALSE );
+    if ( ! vol )
+        return 1;
+
+#if TEST_VERBOSITY > 1
+    printf ( "\nFree blocks: %d\n", adfCountFreeBlocks ( vol ) );
+#endif
+
+    struct File * output = adfOpenFile ( vol, filename, "w" );
+    if ( ! output )
+        return 1;
+
+    int status = 1;
+    for ( int i = 0; i < 1024 * 1024 / blocksize ; ++i ) {
+        if ( adfWriteFile ( output, blocksize, buffer ) != blocksize ) {
+            // OK, not all bytes written
+            status = 0;   
+            break;
+        }
+        //printf ( "\nFree blocks: %d\n", adfCountFreeBlocks ( vol ) );
+    }
+    //adfFlushFile ( output );
+    adfCloseFile ( output );
+
+#if TEST_VERBOSITY > 1
+    printf ( "\nFree blocks: %d\n", adfCountFreeBlocks ( vol ) );
+#endif
+
+    adfUnMount ( vol );
+    adfUnMountDev ( device );
+
+#if TEST_VERBOSITY > 0
+    printf (" -> %s\n", status ? "ERROR" : "OK" );
+#endif
+
+    return status;
+}

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -263,17 +263,17 @@ SECTNUM adfGet1FreeBlock(struct Volume *vol) {
  */
 BOOL adfGetFreeBlocks(struct Volume* vol, int nbSect, SECTNUM* sectList)
 {
-	int i, j;
+    int i, j;
     BOOL diskFull;
     int32_t block = vol->rootBlock;
 
     i = 0;
     diskFull = FALSE;
 /*printf("lastblock=%ld\n",vol->lastBlock);*/
-	while( i<nbSect && !diskFull ) {
+    while ( i < nbSect && !diskFull ) {
         if ( adfIsBlockFree(vol, block) ) {
             sectList[i] = block;
-			i++;
+            i++;
         }
 /*        if ( block==vol->lastBlock )
             block = vol->firstBlock+2;*/

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -277,19 +277,21 @@ BOOL adfGetFreeBlocks(struct Volume* vol, int nbSect, SECTNUM* sectList)
         }
 /*        if ( block==vol->lastBlock )
             block = vol->firstBlock+2;*/
-        if ( (block+vol->firstBlock)==vol->lastBlock )
+        if ( ( block + vol->firstBlock ) == vol->lastBlock ) {
             block = 2;
-        else if (block==vol->rootBlock-1)
-            diskFull = TRUE;
-        else
+        } else {
             block++;
+            if ( block == vol->rootBlock )
+                diskFull = TRUE;
+        }
     }
 
-    if (!diskFull)
+    BOOL gotAllBlocks = ( i == nbSect );
+    if ( gotAllBlocks )
         for(j=0; j<nbSect; j++)
             adfSetBlockUsed( vol, sectList[j] );
 
-    return (i==nbSect);
+    return gotAllBlocks;
 }
 
 


### PR DESCRIPTION
The problem with lclevy/ADFlib#9 was with the function `adfGetFreeBlocks()`, it was not using (ie. marking as used) the last available block. In result, the last available block was reused as the following requested blocks, until all data was "written" (to the same block...). Hence no error, but a file with size larger that image written to the disk (metadata was containing the written size, so 1MB on 880K floppy).

This would happen also if more blocks were requested at a time and _exaclty_ that amount was available - but the bug discussed in the issue was always caused by requesting a single block by `adfCreateNextFileBlock()`.
