### PR TITLE
fopen() like API for adfFileOpen()

### DIFF
--- a/src/adf_file.h
+++ b/src/adf_file.h
@@ -48,6 +48,8 @@ struct AdfFile {
     unsigned posInDataBlk;
     unsigned posInExtBlk;
     BOOL writeMode;
+    BOOL truncateMode;
+    uint32_t maxExtent; /* furthest the file has been written */
     BOOL currentDataBlockChanged;
 };
 

--- a/tests/test_file_append.c
+++ b/tests/test_file_append.c
@@ -59,8 +59,6 @@ void test_file_append ( test_data_t * const tdata )
     // create a new file
     char filename[] = "testfile.tmp";
     struct AdfFile * file = adfFileOpen ( vol, filename, tdata->openMode );
-    ck_assert_ptr_null ( file );  // cannot open a new file in append mode
-    file = adfFileOpen ( vol, filename, "w" );
     ck_assert_msg ( file != 0, "Cannot open file %s for %s", filename, tdata->openMode );
     adfFileClose ( file );
 

--- a/tests/test_file_create.c
+++ b/tests/test_file_create.c
@@ -119,20 +119,21 @@ void test_file_create_with_append ( test_data_t * const tdata )
     // create a new file
     char filename[] = "testfile.tmp";
     struct AdfFile * file = adfFileOpen ( vol, filename, tdata->openMode );
-    ck_assert_ptr_null ( file );
-    adfFileClose ( file );   // should not be needed (but should not fail either)
+    ck_assert_ptr_nonnull ( file );
+    adfFileClose ( file );
 
     // reset volume state (remount)
     adfUnMount ( tdata->vol );
     tdata->vol = adfMount ( tdata->device, 0, FALSE );
 
     // verify free blocks
-    ck_assert_int_eq ( free_blocks_before,
+    const unsigned file_blocks_used_by_empty_file = 1;
+    ck_assert_int_eq ( free_blocks_before - file_blocks_used_by_empty_file,
                        adfCountFreeBlocks ( vol ) );
 
     // verify the number of entries
-    ck_assert_int_eq ( 0, adfDirCountEntries ( vol, vol->curDirPtr ) );
-    
+    ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
+
     // umount volume
     adfUnMount ( tdata->vol );
 }


### PR DESCRIPTION
This is a proposal for adfFileOpen() to behave like C's standard [fopen()](https://www.man7.org/linux/man-pages/man3/fopen.3.html):

|Mode|Access|Creates file if missing?|Truncates file?|Starting position|
|-|-|-|-|-|
|`r`|RO|No|No|Start|
|`r+`|R/W|No|No|Start|
|`w`|R/W|Yes|Yes|Start|
|`w+`|R/W|Yes|Yes|Start|
|`a`|R/W|Yes|No|End|
|`a+`|R/W|Yes|No|End|

What this proposal changes compared to what we had before:

* `adfFileOpen(fname, "a")` _will_ create a file
* modes `r+`, `w+`, `a+` are now supported
* mode `w` and `w+` will track the maximum offset written into the file, and if less than the original file size at adfFileClose() time, will truncate the file to your maximum write offset

Truncate-on-close does _not_ follow C fopen semantics, technically it should truncate on open... but that seems to break more tests, I'd have to look at them to find out what assumptions they are making that truncate-on-open violates