### PR TITLE
Improvements in the adf_file API

### DIFF
--- a/examples/unadf.c
+++ b/examples/unadf.c
@@ -414,7 +414,7 @@ void extract_file(struct AdfVolume *vol, char *filename, char *out, mode_t perms
     uint8_t buf[EXTRACT_BUFFER_SIZE];
     int fd = 0;
 
-    if ( ( f = adfFileOpen ( vol, filename, "r" ) ) == NULL )  {
+    if ( ( f = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ ) ) == NULL )  {
         fprintf(stderr, "%s: can't find file %s in volume\n", adf_file, filename);
         goto error_handler;
     }

--- a/regtests/Test/access.c
+++ b/regtests/Test/access.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    fic = adfFileOpen ( vol, "file_1a", "w" );
+    fic = adfFileOpen ( vol, "file_1a", ADF_FILE_MODE_READWRITE );
     if (!fic) { adfUnMount(vol); adfUnMountDev(hd); adfEnvCleanUp(); exit(1); }
     adfFileWrite ( fic, 1, buf );
     adfFileClose ( fic );

--- a/regtests/Test/comment.c
+++ b/regtests/Test/comment.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    fic = adfFileOpen ( vol, "file_1a", "w" );
+    fic = adfFileOpen ( vol, "file_1a", ADF_FILE_MODE_READWRITE );
     if (!fic) { adfUnMount(vol); adfUnMountDev(hd); adfEnvCleanUp(); exit(1); }
     adfFileWrite ( fic, 1, buf );
     adfFileClose ( fic );

--- a/regtests/Test/dispsect.c
+++ b/regtests/Test/dispsect.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    fic = adfFileOpen ( vol, "file_1a", "w" );
+    fic = adfFileOpen ( vol, "file_1a", ADF_FILE_MODE_READWRITE );
     if (!fic) { adfUnMount(vol); adfUnMountDev(hd); adfEnvCleanUp(); exit(1); }
     adfFileWrite ( fic, 1, buf );
     adfFileClose ( fic );

--- a/regtests/Test/file_read_hard_link_test.c
+++ b/regtests/Test/file_read_hard_link_test.c
@@ -145,7 +145,8 @@ int test_hlink_read ( reading_test_t * test_data )
         }
     }
 
-    struct AdfFile * const file_adf = adfFileOpen ( vol, test_data->hlink_name, "r" );
+    struct AdfFile * const file_adf = adfFileOpen ( vol, test_data->hlink_name,
+                                                    ADF_FILE_MODE_READ );
     if ( ! file_adf ) {
         fprintf ( stderr, " -> Cannot open hard link file %s - aborting...\n",
                   test_data->hlink_name );

--- a/regtests/Test/file_seek_after_write.c
+++ b/regtests/Test/file_seek_after_write.c
@@ -279,7 +279,7 @@ unsigned test_seek_after_write ( const test_data_t * const test_data )
 
     // create a new file in th ADF volume
     const char filename[] = "testfile_chunk_overwrite.tmp";
-    struct AdfFile * file = adfFileOpen ( vol, filename, "w" );
+    struct AdfFile * file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     if ( file == NULL )  {
         errors += 1;
         goto cleanup;
@@ -293,7 +293,7 @@ unsigned test_seek_after_write ( const test_data_t * const test_data )
 
     // write file without seek (for off-line comparison / double-check)
     const char filename2[] = "testfile_wo_seek.tmp";
-    file = adfFileOpen ( vol, filename2, "w" );
+    file = adfFileOpen ( vol, filename2, ADF_FILE_MODE_READWRITE );
     if ( file == NULL )  {
         errors += 1;
         goto cleanup;
@@ -311,7 +311,7 @@ unsigned test_seek_after_write ( const test_data_t * const test_data )
     errors += verify_file_data ( vol, filename2, buffer_random, bufsize, 10 );
     
     // reopen the test file
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     if ( file == NULL )  {
         errors += 1;
         goto cleanup;
@@ -390,7 +390,7 @@ unsigned verify_overwritten_data ( struct AdfVolume * const vol,
                                    const unsigned           chunksize )
 {
     unsigned nerrors = 0;
-    struct AdfFile * const file = adfFileOpen ( vol, filename, "r" );
+    struct AdfFile * const file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     if ( file == NULL )
         return 1;
 
@@ -481,7 +481,7 @@ unsigned verify_file_data ( struct AdfVolume * const    vol,
                             const unsigned              bytes_written,  // == bufsize (!)
                             const unsigned              errors_max )
 {
-    struct AdfFile * output = adfFileOpen ( vol, filename, "r" );
+    struct AdfFile * output = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     if ( ! output )
         return 1;
 

--- a/regtests/Test/file_seek_test.c
+++ b/regtests/Test/file_seek_test.c
@@ -155,7 +155,7 @@ int run_single_seek_tests ( reading_test_t * test_data )
     int status = 0;
     for ( unsigned int i = 0 ; i < test_data->nchecks - 1; ++i ) {
 
-        struct AdfFile * file = adfFileOpen ( vol, test_data->filename, "r" );
+        struct AdfFile * file = adfFileOpen ( vol, test_data->filename, ADF_FILE_MODE_READ );
         if ( ! file ) {
             printf ("Cannot open file %s - aborting...\n", test_data->filename );
             status = 1;
@@ -169,7 +169,7 @@ int run_single_seek_tests ( reading_test_t * test_data )
     }
 
     // test EOF
-    struct AdfFile * file = adfFileOpen ( vol, test_data->filename, "r" );
+    struct AdfFile * file = adfFileOpen ( vol, test_data->filename, ADF_FILE_MODE_READ );
     if ( ! file ) {
         printf ("Cannot open file %s - aborting...\n", test_data->filename );
         status = 1;

--- a/regtests/Test/file_seek_test2.c
+++ b/regtests/Test/file_seek_test2.c
@@ -101,7 +101,8 @@ int run_multiple_seek_tests ( test_file_t * test_data )
 #endif
 
     int status = 0;
-    struct AdfFile * const file_adf = adfFileOpen ( vol, test_data->filename_adf, "r" );
+    struct AdfFile * const file_adf = adfFileOpen ( vol, test_data->filename_adf,
+                                                    ADF_FILE_MODE_READ );
     if ( ! file_adf ) {
         fprintf ( stderr, "Cannot open adf file %s - aborting...\n",
                   test_data->filename_adf );

--- a/regtests/Test/file_test.c
+++ b/regtests/Test/file_test.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
 
     adfVolumeInfo(vol);
 
-    file = adfFileOpen ( vol, "mod.and.distantcall", "r" );
+    file = adfFileOpen ( vol, "mod.and.distantcall", ADF_FILE_MODE_READ );
     if (!file) return 1;
     out = fopen("mod.distant","wb");
     if (!out) return 1;
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
 
     adfFileClose ( file );
 
-    file = adfFileOpen ( vol, "emptyfile", "r" );
+    file = adfFileOpen ( vol, "emptyfile", ADF_FILE_MODE_READ );
     if (!file) { 
 		adfUnMount(vol); adfUnMountDev(hd); 
         fprintf(stderr, "can't open file\n");
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 
     adfVolumeInfo(vol);
 
-    file = adfFileOpen ( vol, "moon.gif", "r" );
+    file = adfFileOpen ( vol, "moon.gif", ADF_FILE_MODE_READ );
     if (!file) return 1;
     out = fopen("moon_gif","wb");
     if (!out) return 1;

--- a/regtests/Test/file_test2.c
+++ b/regtests/Test/file_test2.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
 
 
     /* write one file */
-    file = adfFileOpen ( vol, "moon_gif", "w" );
+    file = adfFileOpen ( vol, "moon_gif", ADF_FILE_MODE_READWRITE );
     if (!file) return 1;
     out = fopen( argv[2],"rb");
     if (!out) return 1;
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
 
 
     /* re read this file */
-    file = adfFileOpen ( vol, "moon_gif", "r" );
+    file = adfFileOpen ( vol, "moon_gif", ADF_FILE_MODE_READ );
     if (!file) return 1;
     out = fopen("moon__gif","wb");
     if (!out) return 1;

--- a/regtests/Test/file_test3.c
+++ b/regtests/Test/file_test3.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
 
 
     /* write one file */
-    file = adfFileOpen ( vol, "moon_gif", "w" );
+    file = adfFileOpen ( vol, "moon_gif", ADF_FILE_MODE_READWRITE );
     if (!file) return 1;
     out = fopen( argv[2],"rb");
     if (!out) return 1;
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
 
 
     /* re read this file */
-    file = adfFileOpen ( vol, "moon_gif", "r" );
+    file = adfFileOpen ( vol, "moon_gif", ADF_FILE_MODE_READ );
     if (!file) return 1;
     out = fopen("moon__gif","wb");
     if (!out) return 1;

--- a/regtests/Test/floppy_overfilling_test.c
+++ b/regtests/Test/floppy_overfilling_test.c
@@ -114,7 +114,7 @@ int test_floppy_overfilling ( test_data_t * const tdata )
     printf ( "\nFree blocks: %d\n", adfCountFreeBlocks ( vol ) );
 #endif
 
-    struct AdfFile * output = adfFileOpen ( vol, tdata->filename, "w" );
+    struct AdfFile * output = adfFileOpen ( vol, tdata->filename, ADF_FILE_MODE_READWRITE );
     if ( ! output )
         return 1;
 
@@ -174,7 +174,7 @@ int verify_file_data ( struct AdfVolume * const vol,
                        const unsigned           bytes_written,
                        const int                max_errors )
 {
-    struct AdfFile * output = adfFileOpen ( vol, filename, "r" );
+    struct AdfFile * output = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     if ( ! output )
         return 1;
 

--- a/regtests/Test/rename.c
+++ b/regtests/Test/rename.c
@@ -55,22 +55,22 @@ int main(int argc, char *argv[])
 
     adfVolumeInfo(vol);
 
-    fic = adfFileOpen ( vol, "file_1a", "w" );
+    fic = adfFileOpen ( vol, "file_1a", ADF_FILE_MODE_READWRITE );
     if (!fic) { adfUnMount(vol); adfUnMountDev(hd); adfEnvCleanUp(); exit(1); }
     adfFileWrite ( fic, 1, buf );
     adfFileClose ( fic );
 
-    fic = adfFileOpen ( vol, "file_24", "w" );
+    fic = adfFileOpen ( vol, "file_24", ADF_FILE_MODE_READWRITE );
     if (!fic) { adfUnMount(vol); adfUnMountDev(hd); adfEnvCleanUp(); exit(1); }
     adfFileWrite ( fic, 1, buf );
     adfFileClose ( fic );
 
-    fic = adfFileOpen ( vol, "dir_1a", "w" );
+    fic = adfFileOpen ( vol, "dir_1a", ADF_FILE_MODE_READWRITE );
     if (!fic) { adfUnMount(vol); adfUnMountDev(hd); adfEnvCleanUp(); exit(1); }
     adfFileWrite ( fic, 1, buf );
     adfFileClose ( fic );
 
-    fic = adfFileOpen ( vol, "dir_5u", "w" );
+    fic = adfFileOpen ( vol, "dir_5u", ADF_FILE_MODE_READWRITE );
     if (!fic) { adfUnMount(vol); adfUnMountDev(hd); adfEnvCleanUp(); exit(1); }
     adfFileWrite ( fic, 1, buf );
     adfFileClose ( fic );
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
 
     puts("Create dir_5u, Rename dir_3 into toto");
 /*
-    fic = adfOpenFile(vol, "dir_5u","w");
+    fic = adfOpenFile ( vol, "dir_5u", ADF_FILE_MODE_READWRITE );
     if (!fic) { adfUnMount(vol); adfUnMountDev(hd); adfEnvCleanUp(); exit(1); }
     adfWriteFile(fic,1,buf);
     adfCloseFile(fic);

--- a/regtests/Test/undel.c
+++ b/regtests/Test/undel.c
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    fic = adfFileOpen ( vol, "file_1a", "w" );
+    fic = adfFileOpen ( vol, "file_1a", ADF_FILE_MODE_READWRITE );
     if (!fic) { adfUnMount(vol); adfUnMountDev(hd); adfEnvCleanUp(); exit(1); }
     adfFileWrite ( fic, 1, buf );
     adfFileClose ( fic );

--- a/regtests/Test/undel2.c
+++ b/regtests/Test/undel2.c
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
     }
     adfFreeDirList(list);
 
-    file = adfFileOpen ( vol, "mod.and.distantcall", "r" );
+    file = adfFileOpen ( vol, "mod.and.distantcall", ADF_FILE_MODE_READ );
     if (!file) return 1;
     out = fopen("mod.distant","wb");
     if (!out) return 1;

--- a/regtests/Test/undel3.c
+++ b/regtests/Test/undel3.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
     }
     adfFreeDirList(list);
 
-    file = adfFileOpen ( vol, "MOON.GIF", "r" );
+    file = adfFileOpen ( vol, "MOON.GIF", ADF_FILE_MODE_READ );
     if (!file) return 1;
     out = fopen("moon_gif","wb");
     if (!out) return 1;

--- a/src/adf_file.c
+++ b/src/adf_file.c
@@ -914,16 +914,6 @@ uint32_t adfFileRead ( struct AdfFile * const file,
 
 
 /*
- * adfEndOfFile
- *
- */
-BOOL adfEndOfFile ( const struct AdfFile * const file )
-{
-    return ( file->pos == file->fileHdr->byteSize );
-}
-
-
-/*
  * adfReadNextFileBlock
  *
  */

--- a/src/adf_file.h
+++ b/src/adf_file.h
@@ -84,6 +84,16 @@ PREFIX uint32_t adfFileRead ( struct AdfFile * const file,
 PREFIX RETCODE adfFileSeek ( struct AdfFile * const file,
                              const uint32_t         pos );		/* BV */
 
+static inline RETCODE adfFileSeekStart ( struct AdfFile * const file ) {
+    return adfFileSeek ( file, 0 );
+}
+
+
+static inline RETCODE adfFileSeekEOF ( struct AdfFile * const file ) {
+    return adfFileSeek ( file, adfFileGetSize ( file ) );
+}
+
+
 RETCODE adfFileReadNextBlock ( struct AdfFile * const file );
 
 PREFIX uint32_t adfFileWrite ( struct AdfFile * const file,

--- a/src/adf_file.h
+++ b/src/adf_file.h
@@ -52,6 +52,19 @@ struct AdfFile {
 };
 
 
+static inline uint32_t adfFileGetPos ( const struct AdfFile * const file ) {
+    return file->pos;
+}
+
+static inline uint32_t adfFileGetSize ( const struct AdfFile * const file ) {
+    return file->fileHdr->byteSize;
+}
+
+static inline BOOL adfEndOfFile ( const struct AdfFile * const file ) {
+    return ( file->pos == file->fileHdr->byteSize );
+}
+
+
 PREFIX int32_t adfPos2DataBlock ( const unsigned   pos,
                                   const unsigned   blockSize,
                                   unsigned * const posInExtBlk,
@@ -67,8 +80,6 @@ PREFIX void adfFileClose ( struct AdfFile * const file );
 PREFIX uint32_t adfFileRead ( struct AdfFile * const file,
                               const uint32_t         n,
                               uint8_t * const        buffer );
-
-PREFIX BOOL adfEndOfFile ( const struct AdfFile * const file );
 
 PREFIX RETCODE adfFileSeek ( struct AdfFile * const file,
                              const uint32_t         pos );		/* BV */

--- a/src/adf_file.h
+++ b/src/adf_file.h
@@ -52,6 +52,12 @@ struct AdfFile {
 };
 
 
+typedef enum {
+    ADF_FILE_MODE_READ,
+    ADF_FILE_MODE_READWRITE
+} AdfFileMode;
+
+
 static inline uint32_t adfFileGetPos ( const struct AdfFile * const file ) {
     return file->pos;
 }
@@ -73,7 +79,7 @@ PREFIX int32_t adfPos2DataBlock ( const unsigned   pos,
 
 PREFIX struct AdfFile * adfFileOpen ( struct AdfVolume * const vol,
                                       const char * const       name,
-                                      const char * const       mode );
+                                      const AdfFileMode        mode );
 
 PREFIX void adfFileClose ( struct AdfFile * const file );
 

--- a/tests/test_file_append.c
+++ b/tests/test_file_append.c
@@ -16,7 +16,7 @@ typedef struct test_data_s {
     char *          volname;
     uint8_t         fstype;   // 0 - OFS, 1 - FFS
     unsigned        nVolumeBlocks;
-    char *          openMode;  // "w" or "a"
+    AdfFileMode     openMode;
 } test_data_t;
 
 
@@ -59,9 +59,12 @@ void test_file_append ( test_data_t * const tdata )
     // create a new file
     char filename[] = "testfile.tmp";
     struct AdfFile * file = adfFileOpen ( vol, filename, tdata->openMode );
-    ck_assert_ptr_null ( file );  // cannot open a new file in append mode
-    file = adfFileOpen ( vol, filename, "w" );
-    ck_assert_msg ( file != 0, "Cannot open file %s for %s", filename, tdata->openMode );
+    //ck_assert_ptr_null ( file );  // cannot open a new file in append mode
+    //file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
+    ck_assert_msg ( file != 0, "Cannot open file %s for %s", filename,
+                    tdata->openMode == ADF_FILE_MODE_READ      ? "reading" :
+                    tdata->openMode == ADF_FILE_MODE_READWRITE ? "writing" :
+                    "an unknown mode" );
     adfFileClose ( file );
 
     // reset volume state (remount)
@@ -77,17 +80,7 @@ void test_file_append ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
-    ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
-    ck_assert_uint_eq ( 0, file->pos );
-    ck_assert_int_eq ( 0, file->posInExtBlk );
-    //ck_assert_int_eq ( 0, file->posInDataBlk );
-    ck_assert_int_eq ( 0, file->nDataBlock );
-    ck_assert_int_eq ( adfEndOfFile ( file ), TRUE );
-    adfFileClose ( file );
-
-    // the same when open for appending
-    file = adfFileOpen ( vol, filename, "a" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -97,7 +90,7 @@ void test_file_append ( test_data_t * const tdata )
     adfFileClose ( file );
 
     // the same when open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -109,11 +102,20 @@ void test_file_append ( test_data_t * const tdata )
 
     ///
     /// test writing 1 byte to the created above, empty file
-    /// in append mode
     ///
 
-    // open for appending
-    file = adfFileOpen ( vol, filename, "a" );
+    // open for writing
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
+    ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
+    ck_assert_int_eq ( file->fileHdr->firstData, 0 );
+    ck_assert_uint_eq ( 0, file->pos );
+    ck_assert_int_eq ( 0, file->posInExtBlk );
+    //ck_assert_int_eq ( 0, file->posInDataBlk );
+    ck_assert_int_eq ( 0, file->nDataBlock );
+    ck_assert_int_eq ( adfEndOfFile ( file ), TRUE );
+
+    RETCODE rc = adfFileSeek ( file, adfFileGetSize ( file ) );
+    ck_assert_int_eq ( rc, RC_OK );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_int_eq ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -147,7 +149,7 @@ void test_file_append ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 1, file->fileHdr->byteSize );
     ck_assert_int_gt ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -178,7 +180,7 @@ START_TEST ( test_file_append_ofs )
         .adfname = "test_file_append_ofs.adf",
         .volname = "Test_file_append_ofs",
         .fstype  = 0,          // OFS
-        .openMode = "a",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     setup ( &test_data );
@@ -194,7 +196,7 @@ START_TEST ( test_file_append_ffs )
         .adfname = "test_file_append_ffs.adf",
         .volname = "Test_file_append_ffs",
         .fstype  = 1,          // FFS
-        .openMode = "a",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     setup ( &test_data );
@@ -208,9 +210,6 @@ Suite * adflib_suite ( void )
 {
     Suite * s = suite_create ( "adflib" );
 
-    
-    /* *** tests disabled - append more removed (at least for now) ***
-
     TCase * tc = tcase_create ( "check framework" );
     tcase_add_test ( tc, test_check_framework );
     suite_add_tcase ( s, tc );
@@ -223,7 +222,6 @@ Suite * adflib_suite ( void )
     tc = tcase_create ( "adflib test_file_append_ffs" );
     tcase_add_test ( tc, test_file_append_ffs );
     suite_add_tcase ( s, tc );
-    */
 
     return s;
 }

--- a/tests/test_file_create.c
+++ b/tests/test_file_create.c
@@ -16,7 +16,7 @@ typedef struct test_data_s {
     char *          volname;
     uint8_t         fstype;   // 0 - OFS, 1 - FFS
     unsigned        nVolumeBlocks;
-    char *          openMode;  // "w" or "a"
+    AdfFileMode     openMode;
 } test_data_t;
 
 
@@ -66,7 +66,7 @@ void test_file_create ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -86,7 +86,7 @@ void test_file_create ( test_data_t * const tdata )
     adfFileClose ( file );
 */
     // the same when open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -145,7 +145,7 @@ START_TEST ( test_file_create_empty_ofs_write )
         .adfname = "test_file_create_ofs_write.adf",
         .volname = "Test_file_create_ofs",
         .fstype  = 0,          // OFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     setup ( &test_data );
@@ -161,7 +161,7 @@ START_TEST ( test_file_create_empty_ffs_write )
         .adfname = "test_file_create_ffs_write.adf",
         .volname = "Test_file_create_ffs",
         .fstype  = 1,          // FFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     setup ( &test_data );

--- a/tests/test_file_overwrite.c
+++ b/tests/test_file_overwrite.c
@@ -16,7 +16,7 @@ typedef struct test_data_s {
     char *          volname;
     uint8_t         fstype;   // 0 - OFS, 1 - FFS
     unsigned        nVolumeBlocks;
-    char *          openMode;  // "w" or "a"
+    AdfFileMode     openMode;
 } test_data_t;
 
 
@@ -60,7 +60,10 @@ void test_file_write ( test_data_t * const tdata )
     const char filename[] = "testfile.tmp";
     struct AdfFile * file = adfFileOpen ( vol, filename, tdata->openMode );
     //ck_assert_ptr_nonnull ( file );
-    ck_assert_msg ( file != 0, "Cannot open file %s for %s", filename, tdata->openMode );
+    ck_assert_msg ( file != 0, "Cannot open file %s for %s", filename,
+                    tdata->openMode == ADF_FILE_MODE_READ      ? "reading" :
+                    tdata->openMode == ADF_FILE_MODE_READWRITE ? "writing" :
+                    "an unknown mode" );
     adfFileClose ( file );
 
     // reset volume state (remount)
@@ -77,7 +80,7 @@ void test_file_write ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -97,7 +100,7 @@ void test_file_write ( test_data_t * const tdata )
     adfFileClose ( file );
 */
     // the same when open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -112,7 +115,7 @@ void test_file_write ( test_data_t * const tdata )
     ///
     
     // open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_int_eq ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -147,7 +150,7 @@ void test_file_write ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 1, file->fileHdr->byteSize );
     ck_assert_int_gt ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -178,7 +181,7 @@ void test_file_write ( test_data_t * const tdata )
     ///
 
     // open the file for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
 
     // verify metadata after opening
     ck_assert_uint_eq ( 1, file->fileHdr->byteSize );
@@ -207,7 +210,7 @@ void test_file_write ( test_data_t * const tdata )
         adfMount ( tdata->device, 0, FALSE );
     
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 1, file->fileHdr->byteSize );
     ck_assert_int_gt ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -237,7 +240,7 @@ START_TEST ( test_file_write_ofs )
         .adfname = "test_file_overwrite_ofs.adf",
         .volname = "Test_file_overwrite_ofs",
         .fstype  = 0,          // OFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     setup ( &test_data );
@@ -252,7 +255,7 @@ START_TEST ( test_file_write_ffs )
         .adfname = "test_file_overwrite_ffs.adf",
         .volname = "Test_file_overwrite_ffs",
         .fstype  = 1,          // FFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     setup ( &test_data );

--- a/tests/test_file_overwrite2.c
+++ b/tests/test_file_overwrite2.c
@@ -17,7 +17,7 @@ typedef struct test_data_s {
     char *          volname;
     uint8_t         fstype;   // 0 - OFS, 1 - FFS
     unsigned        nVolumeBlocks;
-//    char *          openMode;  // "w" or "a"
+//    AdfFileMode          openMode;
     unsigned char * buffer;
     unsigned        bufsize;    // at least 2 bytes
 } test_data_t;
@@ -62,7 +62,7 @@ void test_file_overwrite ( test_data_t * const tdata )
 
     // create a new file
     char filename[] = "testfile.tmp";
-    struct AdfFile * file = adfFileOpen ( vol, filename, "w" );
+    struct AdfFile * file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_ptr_nonnull ( file );
     adfFileClose ( file );
 
@@ -80,7 +80,7 @@ void test_file_overwrite ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -100,7 +100,7 @@ void test_file_overwrite ( test_data_t * const tdata )
     adfFileClose ( file );
 */
     // the same when open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -116,7 +116,7 @@ void test_file_overwrite ( test_data_t * const tdata )
     ///
 
     // open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_int_eq ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -163,7 +163,7 @@ void test_file_overwrite ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( buf1size, file->fileHdr->byteSize );
     ck_assert_int_gt ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -205,7 +205,7 @@ void test_file_overwrite ( test_data_t * const tdata )
     ///
 
     // open the file for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
 
     // verify metadata after opening
     ck_assert_uint_eq ( buf1size, file->fileHdr->byteSize );
@@ -247,7 +247,7 @@ void test_file_overwrite ( test_data_t * const tdata )
         adfMount ( device, 0, FALSE );
     
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( buf2size, file->fileHdr->byteSize );
     ck_assert_int_gt ( file->fileHdr->firstData, 0 );   // 0 is bootblock
     ck_assert_uint_eq ( 0, file->pos );

--- a/tests/test_file_seek.c
+++ b/tests/test_file_seek.c
@@ -17,7 +17,7 @@ typedef struct test_data_s {
     char *             volname;
     uint8_t            fstype;   // 0 - OFS, 1 - FFS
     unsigned           nVolumeBlocks;
-    char *             openMode;  // "w" or "a"
+    AdfFileMode        openMode;
     unsigned char *    buffer;
     unsigned           bufsize;
 } test_data_t;
@@ -76,7 +76,7 @@ void test_file_seek_eof ( test_data_t * const tdata )
         adfMount ( device, 0, FALSE );
     
     // reopen the file
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_ptr_nonnull ( file );
     ck_assert_uint_eq ( file->fileHdr->byteSize, bufsize );
 
@@ -169,7 +169,7 @@ START_TEST ( test_file_seek_eof_ofs )
         .adfname = "test_file_seek_eof_ofs.adf",
         .volname = "Test_file_seek_eof_ofs",
         .fstype  = 0,          // OFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i )  {
@@ -188,7 +188,7 @@ START_TEST ( test_file_seek_eof_ffs )
         .adfname = "test_file_seek_eof_ffs.adf",
         .volname = "Test_file_seek_eof_ffs",
         .fstype  = 1,          // FFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i )  {

--- a/tests/test_file_seek_after_write.c
+++ b/tests/test_file_seek_after_write.c
@@ -17,7 +17,7 @@ typedef struct test_data_s {
     char *             volname;
     uint8_t            fstype;   // 0 - OFS, 1 - FFS
     unsigned           nVolumeBlocks;
-    char *             openMode;  // "w" or "a"
+    AdfFileMode        openMode;
     unsigned char *    buffer;
     unsigned           bufsize;
     unsigned           chunksize;
@@ -229,7 +229,7 @@ START_TEST ( test_file_seek_after_write_ofs )
         .adfname = "test_file_seek_after_write_ofs.adf",
         .volname = "Test_file_seek_after_write_ofs",
         .fstype  = 0,          // OFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i )  {
@@ -253,7 +253,7 @@ START_TEST ( test_file_seek_after_write_ffs )
         .adfname = "test_file_seek_after_write_ffs.adf",
         .volname = "Test_file_seek_after_write_ffs",
         .fstype  = 1,          // FFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i )  {

--- a/tests/test_file_truncate.c
+++ b/tests/test_file_truncate.c
@@ -19,7 +19,7 @@ typedef struct test_data_s {
     char *             volname;
     uint8_t            fstype;   // 0 - OFS, 1 - FFS
     unsigned           nVolumeBlocks;
-    char *             openMode;  // "w" or "a"
+    AdfFileMode        openMode;
     unsigned char *    buffer;
     unsigned           bufsize;
     unsigned           truncsize;
@@ -82,7 +82,7 @@ void test_file_truncate ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_ptr_nonnull ( file );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
@@ -98,7 +98,7 @@ void test_file_truncate ( test_data_t * const tdata )
     ///
     
     // open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_int_eq ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -135,7 +135,7 @@ void test_file_truncate ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( bufsize, file->fileHdr->byteSize );
     ck_assert_int_gt ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -151,7 +151,7 @@ void test_file_truncate ( test_data_t * const tdata )
     const unsigned truncsize = tdata->truncsize;
     
     // truncate the file
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_ptr_nonnull ( file );
 
 #if ( TEST_VERBOSITY >= 1 )
@@ -188,7 +188,7 @@ void test_file_truncate ( test_data_t * const tdata )
         free_blocks_file_truncated, free_blocks_file_truncated_expected, bufsize, truncsize );
     
     // reread the truncated file
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_ptr_nonnull ( file );
     unsigned char * rbuf = malloc ( truncsize + 1 );
     ck_assert_ptr_nonnull ( rbuf );
@@ -291,7 +291,7 @@ void test_file_truncate ( test_data_t * const tdata )
         printf ("Checking the enlarged (zero-filled) part\n");
         fflush (stdout);
 #endif
-        file = adfFileOpen ( vol, filename, "r" );
+        file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
         ck_assert_ptr_nonnull ( file );
         adfFileSeek ( file, bufsize );
         size_t extrasize = truncsize - bufsize;
@@ -368,7 +368,7 @@ START_TEST ( test_file_truncate_ofs )
         .adfname = "test_file_truncate_ofs.adf",
         .volname = "Test_file_truncate_ofs",
         .fstype  = 0,          // OFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i ) {
@@ -392,7 +392,7 @@ START_TEST ( test_file_truncate_ffs )
         .adfname = "test_file_truncate_ffs.adf",
         .volname = "Test_file_truncate_ffs",
         .fstype  = 1,          // FFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i ) {

--- a/tests/test_file_truncate2.c
+++ b/tests/test_file_truncate2.c
@@ -19,7 +19,7 @@ typedef struct test_data_s {
     char *             volname;
     uint8_t            fstype;   // 0 - OFS, 1 - FFS
     unsigned           nVolumeBlocks;
-    char *             openMode;  // "w" or "a"
+    AdfFileMode        openMode;
     unsigned char *    buffer;
     unsigned           bufsize;
     unsigned           truncsize;
@@ -82,7 +82,7 @@ void test_adfFileTruncateGetBlocksToRemove ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -102,7 +102,7 @@ void test_adfFileTruncateGetBlocksToRemove ( test_data_t * const tdata )
     adfFileClose ( file );
 */
     // the same when open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -117,7 +117,7 @@ void test_adfFileTruncateGetBlocksToRemove ( test_data_t * const tdata )
     ///
     
     // open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_int_eq ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -157,7 +157,7 @@ void test_adfFileTruncateGetBlocksToRemove ( test_data_t * const tdata )
     vol = //tdata->vol =
         adfMount ( device, 0, FALSE );
 
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_ptr_nonnull ( file );
 
     const unsigned truncsize = tdata->truncsize;
@@ -245,7 +245,7 @@ START_TEST ( test_file_truncate2_ofs )
         .adfname = "test_file_truncate2_ofs.adf",
         .volname = "Test_file_truncate2_ofs",
         .fstype  = 0,          // OFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i ) {
@@ -269,7 +269,7 @@ START_TEST ( test_file_truncate2_ffs )
         .adfname = "test_file_truncate2_ffs.adf",
         .volname = "Test_file_truncate2_ffs",
         .fstype  = 1,          // FFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i ) {

--- a/tests/test_file_write.c
+++ b/tests/test_file_write.c
@@ -17,7 +17,7 @@ typedef struct test_data_s {
     char *             volname;
     uint8_t            fstype;   // 0 - OFS, 1 - FFS
     unsigned           nVolumeBlocks;
-    char *             openMode;  // "w" or "a"
+    AdfFileMode        openMode;
     unsigned char *    buffer;
     unsigned           bufsize;
 } test_data_t;
@@ -79,7 +79,7 @@ void test_file_write ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -99,7 +99,7 @@ void test_file_write ( test_data_t * const tdata )
     adfFileClose ( file );
 */
     // the same when open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -114,7 +114,7 @@ void test_file_write ( test_data_t * const tdata )
     ///
     
     // open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_int_eq ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -168,7 +168,7 @@ void test_file_write ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( bufsize, file->fileHdr->byteSize );
     ck_assert_int_gt ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -237,7 +237,7 @@ START_TEST ( test_file_write_ofs )
         .adfname = "test_file_write_ofs.adf",
         .volname = "Test_file_write_ofs",
         .fstype  = 0,          // OFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i ) {
@@ -256,7 +256,7 @@ START_TEST ( test_file_write_ffs )
         .adfname = "test_file_write_ffs.adf",
         .volname = "Test_file_write_ffs",
         .fstype  = 1,          // FFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i ) {

--- a/tests/test_file_write_chunks.c
+++ b/tests/test_file_write_chunks.c
@@ -17,7 +17,7 @@ typedef struct test_data_s {
     char *             volname;
     uint8_t            fstype;   // 0 - OFS, 1 - FFS
     unsigned           nVolumeBlocks;
-    char *             openMode;  // "w" or "a"
+    AdfFileMode        openMode;
     unsigned char *    buffer;
     unsigned           bufsize;
     unsigned           chunksize;
@@ -80,7 +80,7 @@ void test_file_write ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -100,7 +100,7 @@ void test_file_write ( test_data_t * const tdata )
     adfFileClose ( file );
 */
     // the same when open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_uint_eq ( 0, file->pos );
     ck_assert_int_eq ( 0, file->posInExtBlk );
@@ -115,7 +115,7 @@ void test_file_write ( test_data_t * const tdata )
     ///
     
     // open for writing
-    file = adfFileOpen ( vol, filename, "w" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READWRITE );
     ck_assert_uint_eq ( 0, file->fileHdr->byteSize );
     ck_assert_int_eq ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -197,7 +197,7 @@ void test_file_write ( test_data_t * const tdata )
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
 
     // verify file information (meta-data)
-    file = adfFileOpen ( vol, filename, "r" );
+    file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_uint_eq ( bufsize, file->fileHdr->byteSize );
     ck_assert_int_gt ( file->fileHdr->firstData, 0 );
     ck_assert_uint_eq ( 0, file->pos );
@@ -282,7 +282,7 @@ START_TEST ( test_file_write_ofs )
         .adfname = "test_file_write_chunks_ofs.adf",
         .volname = "Test_file_write_chunks_ofs",
         .fstype  = 0,          // OFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i ) {
@@ -306,7 +306,7 @@ START_TEST ( test_file_write_ffs )
         .adfname = "test_file_write_chunks_ffs.adf",
         .volname = "Test_file_write_chunks_ffs",
         .fstype  = 1,          // FFS
-        .openMode = "w",
+        .openMode = ADF_FILE_MODE_READWRITE,
         .nVolumeBlocks = 1756
     };
     for ( unsigned i = 0 ; i < buflensize ; ++i ) {

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -12,7 +12,7 @@ unsigned verify_file_data ( struct AdfVolume * const    vol,
                             const unsigned              fsize,
                             const unsigned              errors_max )
 {
-    struct AdfFile * const output = adfFileOpen ( vol, filename, "r" );
+    struct AdfFile * const output = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     if ( ! output )
         return 1;
 
@@ -139,7 +139,7 @@ unsigned validate_file_metadata ( struct AdfVolume * const vol,
                                   const unsigned           errors_max )
 {
     (void) errors_max;
-    struct AdfFile * const file = adfFileOpen ( vol, filename, "r" );
+    struct AdfFile * const file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     if ( ! file )
         return 1;
     unsigned nerrors = validate_file_metadata_last_ext ( file );


### PR DESCRIPTION
1. Changed way of defining the mode in adfFileOpen, the 2 modes replace as follows:
   - `"r"` -> `ADF_FILE_MODE_READ`
   - `"w"` -> `ADF_FILE_MODE_READWRTIE`

2. Added a few useful functions (very simple - static inline):
   - for checking status (position, size)
     - checking EOF changed also to static inline for consistency
   - seeking (start, EOF) 
