### PR TITLE
debug_utils: backtrace check in CMake; corrections in CMake and autotools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,13 @@ if(ADFLIB_BUILD_DLL)
     add_definitions(-DBUILD_DLL)
 endif(ADFLIB_BUILD_DLL)
 
+include( CheckFunctionExists )
+check_function_exists( backtrace HAVE_BACKTRACE )
+check_function_exists( backtrace_symbols HAVE_BACKTRACE_SYMBOLS )
+#include(CheckCXXSymbolExists)
+#check_cxx_symbol_exists(backtrace features HAVE_BACKTRACE)
+#check_cxx_symbol_exists(backtrace_symbols features HAVE_BACKTRACE_SYMBOLS)
+
 enable_testing()
 
 ADD_SUBDIRECTORY( src )

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -3,7 +3,7 @@
     {
       "name": "x64-Debug-Static",
       "generator": "Ninja",
-      "configurationType": "Debug",
+      "configurationType": "DEBUG",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
@@ -14,7 +14,7 @@
     {
       "name": "x64-Debug-Shared",
       "generator": "Ninja",
-      "configurationType": "Debug",
+      "configurationType": "DEBUG",
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
       "cmakeCommandArgs": "-DBUILD_SHARED_LIBS:BOOL=ON -DADFLIB_BUILD_DLL=ON",

--- a/configure.ac
+++ b/configure.ac
@@ -91,9 +91,11 @@ AC_ARG_ENABLE([native_win32],
                esac],
               [])
 
+echo "Native device: ${NATIVE_DIR}"
 AM_CONDITIONAL([NATIVE_GENERIC], [test x${NATIVE_DIR} = xgeneric])
 AM_CONDITIONAL([NATIVE_LINUX],   [test x${NATIVE_DIR} = xlinux])
 AM_CONDITIONAL([NATIVE_WIN32],   [test x${NATIVE_DIR} = xwin32])
+
 
 # Checks for programs.
 AC_PROG_CC

--- a/src/debug_util.c
+++ b/src/debug_util.c
@@ -1,4 +1,6 @@
 
+#include "debug_util.h"
+
 #include <features.h>
 
 /* execinfo.h available only in glibc */
@@ -8,9 +10,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-
-#include "debug_util.h"
-
 
 #ifdef __GLIBC__
 /*
@@ -29,18 +28,20 @@ void adfPrintBacktrace ( void )
     const unsigned BUFSIZE = 100;
     void *buffer [ BUFSIZE ];
 
-    int size = backtrace ( buffer, BUFSIZE );
-    const char * const * const strings = backtrace_symbols ( buffer, size );
+    int size = backtrace ( buffer, (int) BUFSIZE );
+    const char * const * const strings =
+        ( const char * const* const ) backtrace_symbols ( buffer, size );
+
     if ( strings == NULL ) {
         perror ( "error getting symbols" );
         return;
     }
 
     printf ( "Obtained %d stack frames.\n", size );
-    for ( unsigned i = 0 ; i < size ; i++ )
+    for ( int i = 0 ; i < size ; i++ )
         printf ( "%s\n", strings[i] );
 
-    free ( strings );
+    free ( (void *) strings );
 
 }
 #else

--- a/src/debug_util.c
+++ b/src/debug_util.c
@@ -1,4 +1,6 @@
 
+#include <features.h>
+
 /* execinfo.h available only in glibc */
 #ifdef __GLIBC__
 #include <execinfo.h>

--- a/src/debug_util.c
+++ b/src/debug_util.c
@@ -1,19 +1,16 @@
 
 #include "debug_util.h"
 
-#include <features.h>
-
-/* execinfo.h available only in glibc */
-#ifdef __GLIBC__
-#include <execinfo.h>
+#if ( defined HAVE_BACKTRACE && defined HAVE_BACKTRACE_SYMBOLS )
+#include <execinfo.h>    /* required for backtrace() */
 #endif
 
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef __GLIBC__
+#if ( defined HAVE_BACKTRACE && defined HAVE_BACKTRACE_SYMBOLS )
 /*
-  backtrace() only available in glibc
+  backtrace(), backtrace_symbols are available only in glibc
 
   Require link option: -rdynamic
 

--- a/src/debug_util.c
+++ b/src/debug_util.c
@@ -1,6 +1,6 @@
 
-/* CygWin does not have execinfo.h... */
-#ifndef __CYGWIN__
+/* execinfo.h available only in glibc */
+#ifdef __GLIBC__
 #include <execinfo.h>
 #endif
 
@@ -10,8 +10,10 @@
 #include "debug_util.h"
 
 
-#ifndef __CYGWIN__
+#ifdef __GLIBC__
 /*
+  backtrace() only available in glibc
+
   Require link option: -rdynamic
 
   More info:
@@ -40,7 +42,13 @@ void adfPrintBacktrace ( void )
 
 }
 #else
-/* no backtrace under CygWin */
+/* no backtrace without glibc
+
+   ( for Windows, if ever needed, this might be helpful:
+     https://stackoverflow.com/questions/26398064/counterpart-to-glibcs-backtrace-and-backtrace-symbols-on-windows )
+ */
 void adfPrintBacktrace ( void )
-{}
+{
+    fprintf ( stderr, "Sorry, no backtrace without glibc...\n" );
+}
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT CHECK_FOUND)
     find_package(PkgConfig QUIET)
     if (PkgConfig_FOUND)
         set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON)
-        pkg_check_modules ( CHECK check >= 0.11.0 )
+        pkg_check_modules ( CHECK check>=0.11.0 )
     endif (PkgConfig_FOUND)
 endif (NOT CHECK_FOUND)
 


### PR DESCRIPTION
Minor fixes:

1. `debug_util.c`: following #44: indeed, `backtrace` is only in `glibc`, so correcting this.
    * plus some minor corrections in the code
    
    * Note that:
      * this is completely optional code, only to help debugging "special" cases (otherwise could be completely removed); therefore, it should require as little changes in the build system as possible
        (for now used only in CMake debug builds, as autotools have no separated debug configuration, and there is no real need to create one...)

2. Corrected CMake syntax for checking the required Check version.

3. CMake debug mode defined by VS was different (case) than in CMakeLists - corrected.

4. Autotools after 0262bcea was not showing the type of native devices that will be build - corrected.
 