### PR TITLE
Add rebuilding of block allocation bitmap (if marked as invalid in root block)

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -57,6 +57,15 @@ jobs:
       run: make
     - name: make check
       run: make check
+    - name: store logs from failed tests
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: cygwin_native_logs_failed_tests
+        path: |
+          examples/tests/*.log
+          regtests/Test/*.log
+          tests/*.log
     - name: make distcheck
       run: make distcheck
     - name: make install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -115,7 +115,7 @@ jobs:
     runs-on: windows-latest
     needs: windows_build
     steps:
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@v3
       with:
 #        name: adflib-${{ env.ADFLIB_TAG }}-windows
         name: adflib-windows
@@ -123,7 +123,7 @@ jobs:
     - name: list files extracted from the artifact
       shell: bash
       run: find .
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@v3
       with:
         name: adflib-windows-examples-tests
         path: .
@@ -189,7 +189,7 @@ jobs:
     needs: macos_shared
     runs-on: macos-latest
     steps:
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@v3
       with:
 #      name: adflib-${{ env.ADFLIB_TAG }}-macos
         name: adflib-macos
@@ -198,7 +198,7 @@ jobs:
       run: tar xzv -C / -f adflib-macos.tgz
     - name: list files extracted from the artifact
       run: find /usr/local -name "*adf*"
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@v3
       with:
         name: adflib-macos-examples-tests
         path: .

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -107,7 +107,7 @@ jobs:
         tar cvzf artifact-tests/examples_tests.tgz examples/tests/
     - uses: actions/upload-artifact@v3
       with:
-        name: adflib-examples-tests
+        name: adflib-windows-examples-tests
         path: |
           artifact-tests
 
@@ -125,7 +125,7 @@ jobs:
       run: find .
     - uses: actions/download-artifact@master
       with:
-        name: adflib-examples-tests
+        name: adflib-windows-examples-tests
         path: .
     - name: extract examples/tests
       shell: bash
@@ -180,7 +180,7 @@ jobs:
         tar cvzf artifact-tests/examples_tests.tgz examples/tests/
     - uses: actions/upload-artifact@v3
       with:
-        name: adflib-examples-tests
+        name: adflib-macos-examples-tests
         path: |
           artifact-tests
 
@@ -200,7 +200,7 @@ jobs:
       run: find /usr/local -name "*adf*"
     - uses: actions/download-artifact@master
       with:
-        name: adflib-examples-tests
+        name: adflib-macos-examples-tests
         path: .
     - name: extract examples/tests
       run: tar xzvf examples_tests.tgz

--- a/.github/workflows/deb-debian.yml
+++ b/.github/workflows/deb-debian.yml
@@ -64,7 +64,7 @@ jobs:
     container:
       image: debian:${{ matrix.image }}
     steps:
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@v3
       with:
 #        name: adflib-${{ env.ADFLIB_TAG }}-deb-debian
         name: adflib-debian-${{ matrix.image }}
@@ -84,7 +84,7 @@ jobs:
         dpkg -l 'libadf*' ;
         dpkg -l 'libadf*' | grep "libadf" |
         cut -d' ' -f 3 | cut -d':' -f 1 | xargs dpkg -L
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@v3
       with:
 #        name: adflib-${{ env.ADFLIB_TAG }}-deb-debian
         name: adflib-examples-tests-${{ matrix.image }}

--- a/.github/workflows/deb-ubuntu.yml
+++ b/.github/workflows/deb-ubuntu.yml
@@ -53,7 +53,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@v3
       with:
 #        name: adflib-${{ env.ADFLIB_TAG }}-deb-ubuntu
         name: adflib-deb-ubuntu
@@ -68,7 +68,7 @@ jobs:
         dpkg -l 'libadf*' ;
         dpkg -l 'libadf*' | grep "libadf" |
         cut -d' ' -f 3 | cut -d':' -f 1 | xargs dpkg -L
-    - uses: actions/download-artifact@master
+    - uses: actions/download-artifact@v3
       with:
 #        name: adflib-${{ env.ADFLIB_TAG }}-deb-ubuntu
         name: adflib-examples-tests

--- a/INSTALL
+++ b/INSTALL
@@ -103,7 +103,10 @@ Note that:
   to the directories with test binaries (it probably can be fixed and done
   automatically but no time for it now; if sb has good solution for this,
   help welcomed).
-
+  For the x64-Debug-Shared configuration, also the library with the address sanitizer:
+  Microsoft\VisualStudio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64\clang_rt.asan_dbg_dynamic-x86_64.dll
+  has to be copied.
+  (see also: https://stackoverflow.com/questions/66531482/application-crashes-when-using-address-sanitizer-with-msvc )
 
 Testing with CMake
 -------------------

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Usage info is shown when they are executed without any parameters
 
 ### unADF
 
-`unADF` is a unzip like utility for .ADF files:
+`unADF` is an unzip like utility for .ADF files:
 
 ```
 unadf [-lrcsp -v n] dumpname.adf [files-with-path] [-d extractdir]
@@ -204,3 +204,5 @@ and such, very likely release branch(es) will also appear).
 
 [`fuseadf`](https://gitlab.com/t-m/fuseadf) - FUSE-based Linux filesystem allowing
 to mount and access ADF images in read/write mode.
+[`patool`](https://pypi.org/project/patool/) - an archive file manager written
+in Python.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It supports:
 - create, open, close, delete, rename/move a file or a directory
 - file operations: read, write, truncate
 - directory operations: get contents, change current, get parent
+- volume operations: rebuild block allocation bitmap
 - use dir cache to get directory contents
 - hard- and softlinks for accessing files and directories
 
@@ -79,6 +80,11 @@ image or a file/directory inside the Amiga filesystem. In particular, it shows
 contents of Amiga filesystem metadata blocks, it can help understand structure
 of Amiga filesystems (for anyone curious...).
 
+### adf_bitmap
+
+A low-level utility / diagnostic tool for block allocation bitmap of ADF volumes.
+It can display the bitmap or rebuild it (in fact, enforce rebuilding it, even if
+the volume's flag says that the bitmap is valid).
 
 ## Credits:
 
@@ -152,11 +158,16 @@ and treat as such (ie. use in a safe environment like a VM).
 
 **YOU HAVE BEEN WARNED**
 
-### The new (completed) file write support
+### The new (fixed and completed) file write support (but writing still experimental!)
 The (fixed) file read support and the (new) file write support are rather
 well tested, but still, writing is a new feature so do not experiment on
 a unique copy of an ADF image with your precious data. Please do it on a copy
 and report if any issues are encountered.
+Update: The notice above is especially actual that it was discovered that
+the version `0.8.0` and earlier **do not rebuild the block allocation bitmap
+for volumes where it is marked invalid**. In short, this means that if the bitmap
+is really incorrect, writing to such volume may lead to data loss/corruption.
+Because of this, it is strongly advised to **UPDATE TO THE LATEST VERSION**.
 
 (See also TODO).
 

--- a/debian/libadf-utils.install
+++ b/debian/libadf-utils.install
@@ -1,3 +1,4 @@
+examples/.libs/adf_bitmap		/usr/bin
 examples/.libs/adf_floppy_create	/usr/bin
 examples/.libs/adf_floppy_format	/usr/bin
 examples/.libs/adf_show_metadata	/usr/bin

--- a/debian/libadf-utils.manpages
+++ b/debian/libadf-utils.manpages
@@ -1,3 +1,4 @@
+doc/adf_bitmap.1
 doc/adf_floppy_create.1
 doc/adf_floppy_format.1
 doc/adf_show_metadata.1

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -22,6 +22,7 @@ nobase_dist_doc_DATA = \
 	version0.7.9d_gary.txt
 
 dist_man_MANS = \
+	adf_bitmap.1 \
 	adf_floppy_create.1 \
 	adf_floppy_format.1 \
 	adf_show_metadata.1 \

--- a/doc/adf_bitmap.1
+++ b/doc/adf_bitmap.1
@@ -1,0 +1,27 @@
+.TH ADF_BITMAP 1 "Dec 2023"
+.SH NAME
+adf_bitmap \- show or enforce rebuilding block allocation bitmap.
+
+.SH SYNOPSIS
+.B adf_bitmap <\fIcommand\fR> [\fIadf_device\fR]
+.SH DESCRIPTION
+\fBadf_bitmap\fR is a low-level filesystem utility allowing to display
+or to enforce rebuilding the block allocation bitmap of an Amiga volume.
+
+Commands available:
+.TP
+.B show
+display block allocation bitmap of a volume
+.TP
+.B rebuild
+enforce rebuilding block allocation bitmap of a volume (even if it is
+marked as 'valid')
+.
+.SH SEE ALSO
+.BR adf_show_metadata (1), adf_floppy_create (1), adf_floppy_format (1), unadf (1), adflib (3)
+.SH NOTES
+Detailed info about Commodore Amiga filesystems: http://lclevy.free.fr/adflib/adf_info.html
+.SH AUTHOR
+\fBadf_bitmap\fR was written by \fBTomasz Wolak\fR <tomas.wolak@gmail.com>,
+as a part of the ADFlib (https://github.com/lclevy/ADFlib).
+.PP

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,6 +38,8 @@ file (
 
 if ( ADFLIB_ENABLE_TESTS )
     message ( STATUS "Enable tests in examples/" )
+    add_test ( tests/test_examples_basic.sh ${BASH_PROGRAM}
+               tests/test_examples_basic.sh . )
     add_test ( tests/adf-floppy-test.sh ${BASH_PROGRAM}
                tests/adf-floppy-test.sh )
     add_test ( tests/adf-show-metadata-test.sh ${BASH_PROGRAM}

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -5,6 +5,7 @@ bin_PROGRAMS = unadf \
 	adf_show_metadata
 
 dist_check_SCRIPTS = \
+	tests/test_examples_basic.sh \
 	tests/adf-floppy-test.sh \
 	tests/adf-show-metadata-test.sh \
 	tests/unadf-test.sh

--- a/examples/adf_bitmap.c
+++ b/examples/adf_bitmap.c
@@ -65,7 +65,8 @@ int main ( int     argc,
 
     adfEnvInitDefault();
 
-    BOOL mode = ( command == COMMAND_REBUILD ? FALSE : TRUE );
+    AdfAccessMode mode = ( command == COMMAND_REBUILD ? ADF_ACCESS_MODE_READWRITE :
+                                                        ADF_ACCESS_MODE_READONLY );
 
     printf ( "\nOpening image/device:\t'%s' (%s)\n",
              adfname, mode ? "read-only" : "read-write" );

--- a/examples/adf_bitmap.c
+++ b/examples/adf_bitmap.c
@@ -22,14 +22,10 @@ char * num32_to_bit_str ( const uint32_t num,
 unsigned num32_count_bits ( const uint32_t num,
                             const unsigned nskip_bits );
 
-//unsigned num32_count_bits ( const uint32_t num );
-
-
 typedef enum {
     COMMAND_SHOW,
     COMMAND_REBUILD,
-    COMMAND_HELP,
-    COMMAND_UNKNOWN
+    COMMAND_HELP
 } command_t;
 
 
@@ -261,7 +257,7 @@ char * num32_to_bit_str ( const uint32_t num,
                           bitstr32_t     str )
 {
     for (unsigned i = 0, j = 0 ; i <= 31 ; i++, j++ ) {
-        uint32_t mask = 1u << i;        // check endian!
+        uint32_t mask = 1u << i;
         uint32_t bitValue = ( num & mask ) >> i;
         //str[i] = bitValue ? 'o' : '.';
 
@@ -291,104 +287,3 @@ unsigned num32_count_bits ( const uint32_t num,
     }
     return ntrue;
 }
-
-/*
-unsigned num32_count_bits ( const uint32_t num )
-{
-    unsigned ntrue = 0;
-    for ( unsigned i = 0 ; i <= 31 ; i++ ) {
-        uint32_t mask = 1u << i;
-        uint32_t bitValue = ( num & mask ) >> i;
-        ntrue  += bitValue;
-    }
-    return ntrue;
-}
-*/
-
-/*
-void num32_count_bits ( const uint32_t   num,
-                        unsigned * const ntrue,
-                        unsigned * const nfalse )
-{
-    *ntrue = *nfalse = 0;
-    for ( unsigned i = 0 ; i <= 31 ; i++ ) {
-        uint32_t mask = 1u << i;
-        uint32_t bitValue = ( num & mask ) >> i;
-        *ntrue  += bitValue;
-        *nfalse += //( ! bitValue ) & 1u;
-            1u - bitValue;
-    }
-}
-*/
-
-
-#if defined(_WIN32) && !defined(_CYGWIN)
-
-// custom impl. of POSIX's dirname
-// (note that it modifies buffer pointed by path)
-char* dirname(char* path)
-{
-    if (!path)
-        return NULL;
-
-    int len = strlen(path);
-    if (len < 1)
-        return NULL;
-
-    char* last_slash = strrchr(path, '/');
-    if (!last_slash) {
-        // no slash - no directory in path (only basename)
-        path[0] = '.';
-        path[1] = '\0';
-        return path;
-    }
-
-    if (path + len - 1 == last_slash) {
-        // slash at the end of the path - remove it
-        path[len - 1] = '\0';
-    }
-
-    last_slash = strrchr(path, '/');
-    if (!last_slash) {
-        // no directory before basename
-        path[0] = '.';
-        path[1] = '\0';
-        return path;
-    }
-    else {
-        // cut the last slash and the basename from path
-        *last_slash = '\0';
-        return path;
-    }
-}
-
-// custom impl. of POSIX's basename
-// (note that it modifies buffer pointed by path)
-char* basename(char* path)
-{
-    if (!path)
-        return NULL;
-
-    char* last_slash = strrchr(path, '/');
-    if (!last_slash) {
-        // no slash - no directory in path (only basename)
-        return path;
-    }
-
-    int len = strlen(path);
-    if (path + len - 1 == last_slash) {
-        // slash at the end of the path - remove it
-        path[len - 1] = '\0';
-    }
-
-    last_slash = strrchr(path, '/');
-    if (!last_slash) {
-        // no directory before basename
-        return path;
-    }
-    else {
-        // the basename starts after the last slash
-        return last_slash + 1;
-    }
-}
-#endif

--- a/examples/adf_bitmap.c
+++ b/examples/adf_bitmap.c
@@ -90,7 +90,7 @@ int main ( int     argc,
         goto dev_cleanup;
     }
 
-    unsigned volSizeBlocks = (unsigned) (vol->lastBlock - vol->firstBlock) + 1;
+    unsigned volSizeBlocks = adfVolGetBlockNum ( vol );
     printf ( "\nMounted volume:\t\t%d, '%s'\n"
              "\nVolume size in blocks:   \n"
              "   total (including boot block)   %u\n"

--- a/examples/adf_bitmap.c
+++ b/examples/adf_bitmap.c
@@ -121,7 +121,7 @@ env_cleanup:
 
 RETCODE rebuild_bitmap ( struct AdfVolume * const vol )
 {
-    RETCODE rc = adfRemountReadWrite ( vol );
+    RETCODE rc = adfRemount ( vol, ADF_ACCESS_MODE_READWRITE );
     if ( rc != RC_OK ) {
         fprintf ( stderr, "Remounting the volume read-write has failed -"
                   " aborting...\n" );

--- a/examples/adf_floppy_format.c
+++ b/examples/adf_floppy_format.c
@@ -30,7 +30,7 @@ int main ( int     argc,
 
     adfEnvInitDefault();
 
-    struct AdfDevice * device = adfMountDev ( adfname, FALSE );
+    struct AdfDevice * device = adfMountDev ( adfname, ADF_ACCESS_MODE_READWRITE );
     if ( device ) {
         fprintf ( stderr, "The floppy disk %s already contains a filesystem - aborting...\n",
                   adfname );
@@ -38,7 +38,7 @@ int main ( int     argc,
         return 1;
     }
 
-    device = adfOpenDev ( adfname, FALSE );
+    device = adfOpenDev ( adfname, ADF_ACCESS_MODE_READWRITE );
     if ( ! device ) {
         fprintf ( stderr, "Cannot open floppy disk %s - aborting...\n", adfname );
         return 1;

--- a/examples/adf_show_metadata.c
+++ b/examples/adf_show_metadata.c
@@ -45,7 +45,7 @@ int main ( int     argc,
     adfEnvInitDefault();
 
     printf ( "\nOpening image/device:\t'%s'\n", adfname );
-    struct AdfDevice * const dev = adfMountDev ( adfname, TRUE );
+    struct AdfDevice * const dev = adfMountDev ( adfname, ADF_ACCESS_MODE_READONLY );
     if ( ! dev ) {
         fprintf ( stderr, "Cannot open file/device '%s' - aborting...\n",
                   adfname );
@@ -54,7 +54,7 @@ int main ( int     argc,
     }
 
     int vol_id = 0;
-    struct AdfVolume * const vol = adfMount ( dev, vol_id, 1 );
+    struct AdfVolume * const vol = adfMount ( dev, vol_id, ADF_ACCESS_MODE_READONLY );
     if ( ! vol ) {
         fprintf ( stderr, "Cannot mount volume %d - aborting...\n",
                   vol_id );

--- a/examples/adf_show_metadata_volume.c
+++ b/examples/adf_show_metadata_volume.c
@@ -27,16 +27,8 @@ void show_volume_metadata ( struct AdfVolume * const vol )
     }    
     show_bootblock ( &bblock, false );
 
-
     struct bRootBlock rblock;
-
-    //proper calc (?):
-    //numCyls = highCyl - lowCyl + 1
-    //highKey = numCyls * numSurfaces * numBlocksPerTrack - 1
-    //rootKey = INT (numReserved + highKey) / 2
-    uint32_t root_block_sector = //880,
-        //bblock.rootBlock,  // in many images is 0 ???
-        (uint32_t) ( ( vol->lastBlock - vol->firstBlock ) / 2 + 1 ); // this seems to work
+    uint32_t root_block_sector = adfVolCalcRootBlk ( vol );
     printf ("\nRoot block sector:\t%u\n", root_block_sector );
 
     if ( adfReadRootBlock ( vol, root_block_sector, &rblock ) != RC_OK ) {

--- a/examples/tests/test_examples_basic.sh
+++ b/examples/tests/test_examples_basic.sh
@@ -52,6 +52,7 @@ CMDS[5]="adf_floppy_create testflopdd1.adf dd"
 CMDS[6]="adf_floppy_format testflopdd1.adf TestFlopDD1 1"
 CMDS[7]="adf_show_metadata testflopdd1.adf"
 CMDS[8]="rm -v testflopdd1.adf"
+CMDS[9]="adf_bitmap show $TEST_ADF"
 
 for CMD in "${CMDS[@]}"
 do

--- a/examples/tests/test_examples_basic.sh
+++ b/examples/tests/test_examples_basic.sh
@@ -9,13 +9,21 @@
 
 set -e
 
+#if [ $# -ne 1 ]
+#then
+#    echo 2>&1 "Usage: $0 <bin install path>"
+#    exit 1
+#fi
+#PATH=`pwd`/$1:$PATH
+
 if [ $# -ne 1 ]
 then
-    echo 2>&1 "Usage: $0 <bin install path>"
-    exit 1
+    ADF_EXAMPLES_BIN="."
+else
+    ADF_EXAMPLES_BIN="$1"
 fi
 
-PATH=`pwd`/$1:$PATH
+PATH=$ADF_EXAMPLES_BIN:$PATH
 EXAMPLES_TEST_PATH=`dirname $0`
 TEST_ADF=$EXAMPLES_TEST_PATH/arccsh.adf
 

--- a/examples/unadf.c
+++ b/examples/unadf.c
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
     parse_args(argc, argv);
 
     /* mount device */
-    if (!(dev = adfMountDev(adf_file, TRUE))) {
+    if (!(dev = adfMountDev(adf_file, ADF_ACCESS_MODE_READONLY))) {
         fprintf(stderr, "%s: can't mount as device\n", adf_file);
         goto error_handler;
     }
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
             adf_file, vol_number, dev->nVol);
         goto error_handler;
     }
-    if (!(vol = adfMount(dev, vol_number, TRUE))) {
+    if (!(vol = adfMount(dev, vol_number, ADF_ACCESS_MODE_READONLY))) {
         fprintf(stderr, "%s: can't mount volume %d\n",
             adf_file, vol_number);
         goto error_handler;

--- a/regtests/Test/access.c
+++ b/regtests/Test/access.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/bitmap_read_segfault.c
+++ b/regtests/Test/bitmap_read_segfault.c
@@ -37,7 +37,7 @@ int main ( const int          argc,
 
 //	adfSetEnvFct(0,0,MyVer,0);
     BOOL error_status = FALSE;
-    struct AdfDevice * const dev = adfMountDev ( argv[1], FALSE );
+    struct AdfDevice * const dev = adfMountDev ( argv[1], ADF_ACCESS_MODE_READONLY );
     if ( dev == NULL ) {
         log_error ( stderr, "can't mount device %s\n", argv[1] );
         error_status = TRUE;
@@ -45,7 +45,7 @@ int main ( const int          argc,
     }
 
     /*** crash happens here, on mounting the volume, in adfReadBitmap() ***/
-    struct AdfVolume * const vol = adfMount ( dev, 0, FALSE );
+    struct AdfVolume * const vol = adfMount ( dev, 0, ADF_ACCESS_MODE_READONLY );
     if ( vol == NULL ) {
         log_error ( stderr, "can't mount volume %d\n", 0 );
         error_status = TRUE;

--- a/regtests/Test/bitmap_read_segfault.c
+++ b/regtests/Test/bitmap_read_segfault.c
@@ -23,6 +23,8 @@ static void log_error ( FILE * const       file,
     //fprintf ( stderr, "Warning <" );
     vfprintf ( file, format, ap );
     va_end ( ap );
+#else
+    (void) file, (void) format;
 #endif
 }
 

--- a/regtests/Test/bitmap_recreate.c
+++ b/regtests/Test/bitmap_recreate.c
@@ -111,7 +111,7 @@ int main ( const int          argc,
 
 
     /* update the block allocation bitmap */
-    RETCODE rc = adfRemountReadWrite ( volUpdate );
+    RETCODE rc = adfRemount ( volUpdate, ADF_ACCESS_MODE_READWRITE );
     if ( rc != RC_OK ) {
         log_error (
             stderr, "error remounting read-write, volume %d\n", 0 );

--- a/regtests/Test/bitmap_recreate.c
+++ b/regtests/Test/bitmap_recreate.c
@@ -18,7 +18,10 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
+
+#ifndef _WIN32
+#include <unistd.h>   // for unlink()
+#endif
 
 #include "adflib.h"
 

--- a/regtests/Test/bitmap_recreate.c
+++ b/regtests/Test/bitmap_recreate.c
@@ -119,6 +119,29 @@ int main ( const int          argc,
         goto umount_vol_updated;
     }
 
+    struct bRootBlock root;
+    rc = adfReadRootBlock ( volUpdate, (uint32_t) volUpdate->rootBlock, &root );
+    if ( rc != RC_OK ) {
+        adfEnv.eFct ( "Invalid RootBlock, volume %s, sector %u - aborting...",
+                      volUpdate->volName, volUpdate->rootBlock );
+        return rc;
+    }
+
+    rc = adfReconstructBitmap ( volUpdate, &root );
+    if ( rc != RC_OK ) {
+        adfEnv.eFct ( "Error rebuilding the bitmap (%d), volume %s",
+                      rc, volUpdate->volName );
+        return rc;
+    }
+
+    /*
+    rc = adfUpdateBitmap ( vol );
+    if ( rc != RC_OK ) {
+        adfEnv.eFct ( "Error writing updated bitmap (%d), volume %s",
+                      rc, volUpdate->volName );
+        return rc;
+    }
+
     adfUnMount ( volUpdate );
 
     volUpdate = adfMount ( devUpdate, 0,
@@ -128,6 +151,7 @@ int main ( const int          argc,
         error_status = TRUE;
         goto umount_dev_updated;
     }
+    */
 
     /* compare the original and reconstructed */
     unsigned nerrors = compare_bitmaps ( volOrig, volUpdate );

--- a/regtests/Test/bitmap_recreate.c
+++ b/regtests/Test/bitmap_recreate.c
@@ -71,14 +71,16 @@ int main ( const int          argc,
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount the original image */
-    struct AdfDevice * const devOrig = adfMountDev ( adfOrig, FALSE );
+    struct AdfDevice * const devOrig = adfMountDev ( adfOrig,
+                                                     ADF_ACCESS_MODE_READONLY );
     if ( devOrig == NULL ) {
         log_error ( stderr, "can't mount device %s\n", adfOrig );
         error_status = TRUE;
         goto clean_up;
     }
 
-    struct AdfVolume * const volOrig = adfMount ( devOrig, 0, FALSE );
+    struct AdfVolume * const volOrig = adfMount ( devOrig, 0,
+                                                  ADF_ACCESS_MODE_READONLY );
     if ( volOrig == NULL ) {
         log_error ( stderr, "can't mount volume %d\n", 0 );
         error_status = TRUE;
@@ -87,14 +89,17 @@ int main ( const int          argc,
 
     
     /* mount the image copy (for updating) */
-    struct AdfDevice * const devUpdate = adfMountDev ( adfUpdate, FALSE );
+    struct AdfDevice * const devUpdate = adfMountDev ( adfUpdate,
+                                                       ADF_ACCESS_MODE_READWRITE );
+
     if ( devUpdate == NULL ) {
         log_error ( stderr, "can't mount device %s\n", adfUpdate );
         error_status = TRUE;
         goto umount_vol_orig;
     }
 
-    struct AdfVolume * const volUpdate = adfMount ( devUpdate, 0, FALSE );
+    struct AdfVolume * const volUpdate = adfMount ( devUpdate, 0,
+                                                    ADF_ACCESS_MODE_READWRITE );
     if ( volUpdate == NULL ) {
         log_error ( stderr, "can't mount volume %d\n", 0 );
         error_status = TRUE;

--- a/regtests/Test/bitmap_recreate.c
+++ b/regtests/Test/bitmap_recreate.c
@@ -101,8 +101,8 @@ int main ( const int          argc,
         goto umount_vol_orig;
     }
 
-    struct AdfVolume * const volUpdate = adfMount ( devUpdate, 0,
-                                                    ADF_ACCESS_MODE_READWRITE );
+    struct AdfVolume * volUpdate = adfMount ( devUpdate, 0,
+                                              ADF_ACCESS_MODE_READONLY );
     if ( volUpdate == NULL ) {
         log_error ( stderr, "can't mount volume %d\n", 0 );
         error_status = TRUE;
@@ -111,12 +111,22 @@ int main ( const int          argc,
 
 
     /* update the block allocation bitmap */
-    RETCODE rc = adfVolReconstructBitmap ( volUpdate );
+    RETCODE rc = adfRemountReadWrite ( volUpdate );
     if ( rc != RC_OK ) {
         log_error (
-            stderr, "error reconstructing block allocation bitmap, volume %d\n", 0 );
+            stderr, "error remounting read-write, volume %d\n", 0 );
         error_status = TRUE;
         goto umount_vol_updated;
+    }
+
+    adfUnMount ( volUpdate );
+
+    volUpdate = adfMount ( devUpdate, 0,
+                           ADF_ACCESS_MODE_READWRITE );
+    if ( volUpdate == NULL ) {
+        log_error ( stderr, "can't mount volume %d\n", 0 );
+        error_status = TRUE;
+        goto umount_dev_updated;
     }
 
     /* compare the original and reconstructed */

--- a/regtests/Test/bitmap_recreate.c
+++ b/regtests/Test/bitmap_recreate.c
@@ -108,6 +108,7 @@ int main ( const int          argc,
         log_error (
             stderr, "error reconstructing block allocation bitmap, volume %d\n", 0 );
         error_status = TRUE;
+        goto umount_vol_updated;
     }
 
     /* compare the original and reconstructed */
@@ -122,6 +123,7 @@ int main ( const int          argc,
 
     /* cleanup */
 
+umount_vol_updated:
     adfUnMount ( volUpdate );
 
 umount_dev_updated:

--- a/regtests/Test/bitmap_recreate.c
+++ b/regtests/Test/bitmap_recreate.c
@@ -256,8 +256,8 @@ unsigned compare_bitmaps ( struct AdfVolume * const volOrig,
                     valUpdate = bmUpdate.map[i];
                 log_error ( stderr,
                             "bm differ at %u:\n"
-                            "  orig   %10u  %s\n"
-                            "  update %10u  %s\n",
+                            "  orig   0x%08x  %s\n"
+                            "  update 0x%08x  %s\n",
                             i,
                             valOrig,   num32_to_bit_str ( valOrig, bitStrOrig ),
                             valUpdate, num32_to_bit_str ( valUpdate, bitStrUpdate ) );

--- a/regtests/Test/bitmap_recreate.sh
+++ b/regtests/Test/bitmap_recreate.sh
@@ -7,9 +7,9 @@ set -e
 
 echo "----- bitmap_recreate"
 
-for DUMP_ORIG in `ls $DUMPS/*.adf`
+for DUMP_ORIG in $DUMPS/*.adf
 do
-    DUMP=`basename $DUMP_ORIG`
+    DUMP=`basename "${DUMP_ORIG}"`
 
     # exclude failing
     [ "$DUMP" = "cache_crash.adf" ] && continue;
@@ -17,14 +17,14 @@ do
     [ "$DUMP" = "testhd.adf" ]      && continue;
 
     #DUMP_UPDATED=${DUMP}.bitmap_update.adf
-    echo "Copying $DUMP_ORIG to $DUMP $DUMP_UPDATED"
+    echo "Copying ${DUMP_ORIG} to ${DUMP} ${DUMP_UPDATED}"
     #cat $DUMP_ORIG | tee $DUMP > $DUMP_UPDATED
-    cat $DUMP_ORIG > $DUMP
+    cat "${DUMP_ORIG}" > "${DUMP}"
 
-    ./bitmap_recreate $DUMP
+    ./bitmap_recreate "${DUMP}"
 
     #cmp -l ${DUMP_COPY} $DUMP_UPDATED
 
     #rm -fv $DUMP $DUMP_UPDATED
-    rm -fv $DUMP
+    rm -fv "${DUMP}"
 done

--- a/regtests/Test/bitmap_recreate.sh
+++ b/regtests/Test/bitmap_recreate.sh
@@ -16,15 +16,8 @@ do
     [ "$DUMP" = "testffs.adf" ]     && continue;     
     [ "$DUMP" = "testhd.adf" ]      && continue;
 
-    #DUMP_UPDATED=${DUMP}.bitmap_update.adf
-    echo "Copying ${DUMP_ORIG} to ${DUMP} ${DUMP_UPDATED}"
-    #cat $DUMP_ORIG | tee $DUMP > $DUMP_UPDATED
+    echo "Copying ${DUMP_ORIG} to ${DUMP}"
     cat "${DUMP_ORIG}" > "${DUMP}"
-
     ./bitmap_recreate "${DUMP}"
-
-    #cmp -l ${DUMP_COPY} $DUMP_UPDATED
-
-    #rm -fv $DUMP $DUMP_UPDATED
     rm -fv "${DUMP}"
 done

--- a/regtests/Test/bootdisk.c
+++ b/regtests/Test/bootdisk.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/bootdisk2.c
+++ b/regtests/Test/bootdisk2.c
@@ -37,13 +37,13 @@ int main(int argc, char *argv[])
 
     adfEnvInitDefault();
 
-    hd = adfMountDev(argv[2],FALSE);
+    hd = adfMountDev ( argv[2], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 	
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/cache_crash.c
+++ b/regtests/Test/cache_crash.c
@@ -13,8 +13,8 @@ int main(int argc, char *argv[]) {
 
     if (argc <= 1) return 1;
     adfEnvInitDefault();
-    if ((dev = adfMountDev(argv[1], TRUE))) {
-        if ((vol = adfMount(dev, 0, TRUE))) {
+    if ((dev = adfMountDev(argv[1], ADF_ACCESS_MODE_READONLY))) {
+        if ((vol = adfMount(dev, 0, ADF_ACCESS_MODE_READONLY))) {
             /* use dir cache (enables the crash) */
             adfChgEnvProp(PR_USEDIRC, &true);
             /* read all directory entries (crash happens here) */

--- a/regtests/Test/cache_test.c
+++ b/regtests/Test/cache_test.c
@@ -36,13 +36,13 @@ int main(int argc, char *argv[])
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount existing device : FFS */
-    hd = adfMountDev( "testffs.bak",FALSE );
+    hd = adfMountDev ( "testffs.bak", ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/comment.c
+++ b/regtests/Test/comment.c
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/del_test.c
+++ b/regtests/Test/del_test.c
@@ -36,13 +36,13 @@ int main(int argc, char *argv[])
     adfEnvInitDefault();
 
     /* mount existing device */
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount(hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/dir_test.c
+++ b/regtests/Test/dir_test.c
@@ -48,13 +48,13 @@ int main(int argc, char *argv[])
 
     /* mount existing device */
 /* testffs.adf */
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/dir_test.c
+++ b/regtests/Test/dir_test.c
@@ -40,7 +40,6 @@ int main(int argc, char *argv[])
     struct AdfDevice *hd;
     struct AdfVolume *vol;
     struct AdfList *list, *cell;
-    SECTNUM nSect;
  
     adfEnvInitDefault();
 
@@ -73,7 +72,8 @@ int main(int argc, char *argv[])
     putchar('\n');
 
     /* cd dir_2 */
-    nSect = adfChangeDir(vol, "dir_2");
+    //SECTNUM nSect = adfChangeDir(vol, "dir_2");
+    adfChangeDir(vol, "dir_2");
 
     cell = list = adfGetDirEnt(vol,vol->curDirPtr);
     while(cell) {

--- a/regtests/Test/dir_test2.c
+++ b/regtests/Test/dir_test2.c
@@ -37,13 +37,13 @@ int main(int argc, char *argv[])
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount existing device */
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/dir_test_chdir.c
+++ b/regtests/Test/dir_test_chdir.c
@@ -90,14 +90,15 @@ int run_chdir_tests ( chdir_test_t * test_data )
              test_data->image );
 //#endif
 
-    struct AdfDevice * const dev = adfMountDev ( test_data->image, TRUE );
+    struct AdfDevice * const dev = adfMountDev ( test_data->image,
+                                                 ADF_ACCESS_MODE_READONLY );
     if ( ! dev ) {
         fprintf ( stderr, "Cannot mount image %s - aborting the test...\n",
                   test_data->image );
         return 1;
     }
 
-    struct AdfVolume * const vol = adfMount ( dev, 0, TRUE );
+    struct AdfVolume * const vol = adfMount ( dev, 0, ADF_ACCESS_MODE_READONLY );
     if ( ! vol ) {
         fprintf ( stderr, "Cannot mount volume 0 from image %s - aborting the test...\n",
                   test_data->image );

--- a/regtests/Test/dirc.c
+++ b/regtests/Test/dirc.c
@@ -33,13 +33,13 @@ int main(int argc, char *argv[])
 
     /* mount existing device */
 
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/dirc_test.c
+++ b/regtests/Test/dirc_test.c
@@ -32,13 +32,13 @@ int main(int argc, char *argv[])
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount existing device */
-    hd = adfMountDev( "testdirc.adf",FALSE );
+    hd = adfMountDev ( "testdirc.adf", ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/dispsect.c
+++ b/regtests/Test/dispsect.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/file_read_hard_link_test.c
+++ b/regtests/Test/file_read_hard_link_test.c
@@ -109,14 +109,15 @@ int test_hlink_read ( reading_test_t * test_data )
              test_data->real_file );
 #endif
 
-    struct AdfDevice * const dev = adfMountDev ( test_data->image_filename, TRUE );
+    struct AdfDevice * const dev = adfMountDev ( test_data->image_filename,
+                                                 ADF_ACCESS_MODE_READONLY );
     if ( ! dev ) {
         fprintf ( stderr, "Cannot mount image %s - aborting the test...\n",
                   test_data->image_filename );
         return 1;
     }
 
-    struct AdfVolume * const vol = adfMount ( dev, 0, TRUE );
+    struct AdfVolume * const vol = adfMount ( dev, 0, ADF_ACCESS_MODE_READONLY );
     if ( ! vol ) {
         fprintf ( stderr, "Cannot mount volume 0 from image %s - aborting the test...\n",
                   test_data->image_filename );

--- a/regtests/Test/file_seek_after_write.c
+++ b/regtests/Test/file_seek_after_write.c
@@ -247,7 +247,7 @@ unsigned test_seek_after_write ( const test_data_t * const test_data )
     unsigned errors = 0;
 
     // mount volume
-    struct AdfVolume * vol = adfMount ( device, 0, FALSE );
+    struct AdfVolume * vol = adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     if ( vol == NULL ) {
         errors += 1;
         goto umount_device;

--- a/regtests/Test/file_seek_test.c
+++ b/regtests/Test/file_seek_test.c
@@ -134,14 +134,15 @@ int run_single_seek_tests ( reading_test_t * test_data )
     fflush ( stdout );
 #endif
 
-    struct AdfDevice * const dev = adfMountDev ( test_data->image_filename, TRUE );
+    struct AdfDevice * const dev = adfMountDev ( test_data->image_filename,
+                                                 ADF_ACCESS_MODE_READONLY );
     if ( ! dev ) {
         fprintf ( stderr, "Cannot mount image %s - aborting the test...\n",
                   test_data->image_filename );
         return 1;
     }
 
-    struct AdfVolume * const vol = adfMount ( dev, 0, TRUE );
+    struct AdfVolume * const vol = adfMount ( dev, 0, ADF_ACCESS_MODE_READONLY );
     if ( ! vol ) {
         fprintf ( stderr, "Cannot mount volume 0 from image %s - aborting the test...\n",
                  test_data->image_filename );

--- a/regtests/Test/file_seek_test2.c
+++ b/regtests/Test/file_seek_test2.c
@@ -82,14 +82,15 @@ int run_multiple_seek_tests ( test_file_t * test_data )
              test_data->filename_local );
 #endif
 
-    struct AdfDevice * const dev = adfMountDev ( test_data->image_filename, TRUE );
+    struct AdfDevice * const dev = adfMountDev ( test_data->image_filename,
+                                                 ADF_ACCESS_MODE_READONLY );
     if ( ! dev ) {
         fprintf ( stderr, "Cannot mount image %s - aborting the test...\n",
                   test_data->image_filename );
         return 1;
     }
 
-    struct AdfVolume * const vol = adfMount ( dev, 0, TRUE );
+    struct AdfVolume * const vol = adfMount ( dev, 0, ADF_ACCESS_MODE_READONLY );
     if ( ! vol ) {
         printf ( "Cannot mount volume 0 from image %s - aborting the test...\n",
                  test_data->image_filename );

--- a/regtests/Test/file_test.c
+++ b/regtests/Test/file_test.c
@@ -39,13 +39,13 @@ int main(int argc, char *argv[])
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount existing device : FFS */
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");
@@ -89,13 +89,13 @@ int main(int argc, char *argv[])
 
     /* ofs */
 
-    hd = adfMountDev( argv[2],FALSE );
+    hd = adfMountDev ( argv[2], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/file_test2.c
+++ b/regtests/Test/file_test2.c
@@ -40,13 +40,13 @@ int main(int argc, char *argv[])
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount existing device : FFS */
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/file_test2a.c
+++ b/regtests/Test/file_test2a.c
@@ -36,14 +36,14 @@ int main(int argc, char *argv[])
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount existing device : FFS */
-    hd = adfMountDev( "hd.adf",FALSE );
+    hd = adfMountDev ( "hd.adf", ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
     adfDeviceInfo(hd);
 
-    vol = adfMount(hd, 1, FALSE);
+    vol = adfMount ( hd, 1, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/file_test3.c
+++ b/regtests/Test/file_test3.c
@@ -40,9 +40,9 @@ int main(int argc, char *argv[])
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount existing device : OFS */
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
 
     adfVolumeInfo(vol);
 

--- a/regtests/Test/fl_test.c
+++ b/regtests/Test/fl_test.c
@@ -33,13 +33,13 @@ int main(int argc, char *argv[])
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount existing device */
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 	
     adfCreateFlop( hd, "empty", FSMASK_FFS|FSMASK_DIRCACHE );
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/fl_test2.c
+++ b/regtests/Test/fl_test2.c
@@ -32,13 +32,13 @@ int main(int argc, char *argv[])
 //	adfSetEnvFct(0,0,MyVer,0);
 
     /* mount existing device */
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/flfile_test.c
+++ b/regtests/Test/flfile_test.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
     }
     adfCreateFlop( hd, "empty", FSMASK_FFS|FSMASK_DIRCACHE );
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/floppy_overfilling_test.c
+++ b/regtests/Test/floppy_overfilling_test.c
@@ -106,7 +106,7 @@ int test_floppy_overfilling ( test_data_t * const tdata )
         return 1;
     adfCreateFlop ( device, "OverfillTest", tdata->fstype );
 
-    struct AdfVolume * vol = adfMount ( device, 0, FALSE );
+    struct AdfVolume * vol = adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     if ( ! vol )
         return 1;
 

--- a/regtests/Test/hardfile.c
+++ b/regtests/Test/hardfile.c
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
     adfEnvInitDefault();
 
 
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
     adfDeviceInfo(hd);
 
     /* mount the 2 partitions */
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/hardfile2.c
+++ b/regtests/Test/hardfile2.c
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 
     adfDeviceInfo(hd);
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/hd_test.c
+++ b/regtests/Test/hd_test.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
     adfEnvInitDefault();
 
     /*** a real harddisk ***/
-    hd = adfMountDev( argv[1],FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
     adfDeviceInfo(hd);
 
     /* mount the 2 partitions */
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
     }
     adfVolumeInfo(vol);
 
-    vol2 = adfMount(hd, 1, FALSE);
+    vol2 = adfMount(hd, 1, ADF_ACCESS_MODE_READWRITE );
     if (!vol2) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");
@@ -66,14 +66,14 @@ int main(int argc, char *argv[])
 
 
     /*** a dump of a zip disk ***/
-    hd = adfMountDev( argv[2],FALSE );
+    hd = adfMountDev( argv[2], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
     adfDeviceInfo(hd);
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount(hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/hd_test2.c
+++ b/regtests/Test/hd_test2.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
     free(partList);
     free(part1.volName);
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
 
     /* mount the created device */
 
-    hd = adfMountDev ( tmpdevname, FALSE );
+    hd = adfMountDev ( tmpdevname, ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 
     adfDeviceInfo(hd);
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/hd_test3.c
+++ b/regtests/Test/hd_test3.c
@@ -64,13 +64,13 @@ int main(int argc, char *argv[])
     free(part1.volName);
     free(part2.volName);
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");
         adfEnvCleanUp(); exit(1);
     }
-    vol2 = adfMount(hd, 1, FALSE);
+    vol2 = adfMount ( hd, 1, ADF_ACCESS_MODE_READWRITE );
     if (!vol2) {
         adfUnMount(vol);
         adfUnMountDev(hd);
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
 
     /* mount the created device */
 	
-    hd = adfMountDev ( tmpdevname, FALSE );
+    hd = adfMountDev ( tmpdevname, ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);

--- a/regtests/Test/progbar.c
+++ b/regtests/Test/progbar.c
@@ -50,7 +50,7 @@ puts("\ncreate floppy");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/readonly.c
+++ b/regtests/Test/readonly.c
@@ -36,13 +36,13 @@ int main(int argc, char *argv[])
     adfEnvInitDefault();
 
     /* mount existing device */
-    hd = adfMountDev( argv[1], FALSE );
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/readonly.c
+++ b/regtests/Test/readonly.c
@@ -31,7 +31,6 @@ int main(int argc, char *argv[])
     struct AdfDevice *hd;
     struct AdfVolume *vol;
     struct AdfList *list;
-    SECTNUM nSect;
  
     adfEnvInitDefault();
 
@@ -64,7 +63,8 @@ int main(int argc, char *argv[])
     adfCreateDir(vol,vol->curDirPtr,"newdir");
 
     /* cd dir_2 */
-    nSect = adfChangeDir(vol, "same_hash");
+    //SECTNUM nSect = adfChangeDir(vol, "same_hash");
+    adfChangeDir(vol, "same_hash");
 
     list = adfGetDirEnt(vol,vol->curDirPtr);
     while(list) {

--- a/regtests/Test/rename.c
+++ b/regtests/Test/rename.c
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/rename2.c
+++ b/regtests/Test/rename2.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/undel.c
+++ b/regtests/Test/undel.c
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
         adfEnvCleanUp(); exit(1);
     }
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/undel2.c
+++ b/regtests/Test/undel2.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 
     adfChgEnvProp(PR_USEDIRC,&true);
  
-    hd = adfMountDev(argv[1], FALSE);
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 
     adfDeviceInfo(hd);
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/regtests/Test/undel3.c
+++ b/regtests/Test/undel3.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 
     adfChgEnvProp(PR_USEDIRC,&true);
  
-    hd = adfMountDev(argv[1], FALSE);
+    hd = adfMountDev ( argv[1], ADF_ACCESS_MODE_READWRITE );
     if (!hd) {
         fprintf(stderr, "can't mount device\n");
         adfEnvCleanUp(); exit(1);
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 
     adfDeviceInfo(hd);
 
-    vol = adfMount(hd, 0, FALSE);
+    vol = adfMount ( hd, 0, ADF_ACCESS_MODE_READWRITE );
     if (!vol) {
         adfUnMountDev(hd);
         fprintf(stderr, "can't mount volume\n");

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -136,8 +136,10 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
     {
         vol->bitmap.blocks[j] = bmSect = root->bmPages[i];
         if ( ! isSectNumValid ( vol, bmSect ) ) {
-            adfEnv.wFct ( "adfReadBitmap : sector %d out of range", bmSect );
-            // abort here?
+            adfEnv.wFct ( "adfReadBitmap: sector %d out of range, root bm[%u]",
+                          bmSect, i );
+            adfFreeBitmap ( vol );
+            return RC_ERROR;
         }
 
         rc = adfReadBitmapBlock ( vol, bmSect, vol->bitmap.table[j] );

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -336,6 +336,7 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
 
     /* check for erratic (?) (non-zero) entries in bmpages beyond the expected size,
        more info:  https://github.com/lclevy/ADFlib/issues/63 */
+#if CHECK_NONZERO_BMPAGES_BEYOND_BMSIZE == 1
     for ( uint32_t i2 = i ; i2 < BM_PAGES_ROOT_SIZE ; i2++ ) {
         if ( root->bmPages[i2] != 0 )
             adfEnv.wFct ( "adfReconstructBitmap: a non-zero (%u, 0x%02x) entry in rootblock "
@@ -347,9 +348,12 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
     // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     //     -> REPAIR INSTEAD (?) -> JUST SET TO 0
     //
+#endif
 
     SECTNUM bmExtSect = root->bmExt;
+#if CHECK_NONZERO_BMPAGES_BEYOND_BMSIZE == 1
     unsigned bmExt_i = 0;
+#endif
     while ( bmExtSect != 0 ) {
         struct bBitmapExtBlock bmExtBlock;
 
@@ -380,6 +384,7 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
 
         /* check for erratic (?) (non-zero) entries in bmpages beyond the expected size,
            more info:  https://github.com/lclevy/ADFlib/issues/63 */
+#if CHECK_NONZERO_BMPAGES_BEYOND_BMSIZE == 1
         for ( uint32_t i2 = i ; i2 < BM_PAGES_EXT_SIZE ; i2++ ) {
             if ( bmExtBlock.bmPages[i2] != 0 )
                 adfEnv.wFct (
@@ -393,6 +398,7 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
                     vol->bitmap.size );
         }
         bmExt_i++;
+#endif
 
         bmExtSect = bmExtBlock.nextBlock;
     }

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -120,7 +120,6 @@ uint32_t adfCountFreeBlocks ( const struct AdfVolume * const vol )
 RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
                         const struct bRootBlock * const root )
 {
-    struct bBitmapExtBlock bmExt;
     RETCODE rc = RC_OK;
 
     for ( unsigned i = 0 ; i < vol->bitmap.size ; i++ ) {
@@ -159,6 +158,10 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
                           root->bmPages[i2], root->bmPages[i2], i2, vol->bitmap.size );
     }
 
+    if ( root->bmExt == 0 )
+        return rc;
+
+    struct bBitmapExtBlock bmExt;
     nSect = root->bmExt;
     while ( nSect != 0 ) {
         /* bitmap pointers in bitmapExtBlock, j <= mapSize */

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -323,8 +323,10 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
         while ( i < BM_PAGES_EXT_SIZE && j < vol->bitmap.size ) {
             SECTNUM bmBlkPtr = bmExtBlock.bmPages[i];
             if ( ! isSectNumValid ( vol, bmBlkPtr ) ) {
-                adfEnv.wFct ( "adfReadBitmap : sector %d out of range", bmBlkPtr );
-                // abort here?
+                adfEnv.eFct ( "adfReconstructBitmap : sector %d out of range, "
+                              "bmext %d bmpages[%u]", bmBlkPtr, bmExtSect, i );
+                adfFreeBitmap ( vol );
+                return RC_ERROR;
             }
             vol->bitmap.blocks[j] = bmBlkPtr;
 

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -451,8 +451,7 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
 
     // any other blocks to check????
 
-    // immediate update ?
-    return ( rc == RC_OK ) ? adfUpdateBitmap ( vol ) : rc;
+    return rc;
 }
 
 

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -132,6 +132,7 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
     /* bitmap pointers in rootblock : 0 <= i < BM_PAGES_ROOT_SIZE */
     SECTNUM nSect;
     while ( i < vol->bitmap.size &&
+            i < BM_PAGES_ROOT_SIZE &&
             root->bmPages[i] != 0 )
     {
         vol->bitmap.blocks[j] = nSect = root->bmPages[i];
@@ -218,6 +219,7 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
     /* bitmap pointers in rootblock : 0 <= i < BM_PAGES_ROOT_SIZE */
     SECTNUM nSect;
     while ( i < vol->bitmap.size &&
+            i < BM_PAGES_ROOT_SIZE &&
             root->bmPages[i] != 0 )
     {
         vol->bitmap.blocks[j] = nSect = root->bmPages[i];

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -271,7 +271,7 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
 
     // all bitmap blocks are to update (to improve/optimize, ie. compare with existing)
     for ( unsigned i = 0 ; i < vol->bitmap.size ; i++ ) {
-        vol->bitmap.blocksChg[i] = TRUE;  // FALSE;
+        vol->bitmap.blocksChg[i] = TRUE;
     }
 
     uint32_t i = 0,
@@ -309,12 +309,12 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
     //     -> REPAIR INSTEAD (?) -> JUST SET TO 0
     //
 
-    nSect = root->bmExt;
-    while ( nSect != 0 ) {
+    SECTNUM bmExtSect = root->bmExt;
+    while ( bmExtSect != 0 ) {
         struct bBitmapExtBlock bmExtBlock;
 
         /* bitmap pointers in bitmapExtBlock, j <= mapSize */
-        rc = adfReadBitmapExtBlock ( vol, nSect, &bmExtBlock );
+        rc = adfReadBitmapExtBlock ( vol, bmExtSect, &bmExtBlock );
         if ( rc != RC_OK ) {
             adfFreeBitmap(vol);
             return rc;
@@ -349,7 +349,7 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
                     i2, vol->bitmap.size );
         }
 
-        nSect = bmExtBlock.nextBlock;
+        bmExtSect = bmExtBlock.nextBlock;
     }
 
     // initially - set all free

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -120,7 +120,6 @@ uint32_t adfCountFreeBlocks ( const struct AdfVolume * const vol )
 RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
                         const struct bRootBlock * const root )
 {
-    uint32_t i, j;
     struct bBitmapExtBlock bmExt;
     RETCODE rc = RC_OK;
 
@@ -128,7 +127,8 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
         vol->bitmap.blocksChg[i] = FALSE;
     }
 
-    j=0; i=0;
+    uint32_t j = 0,
+             i = 0;
     /* bitmap pointers in rootblock : 0 <= i < BM_PAGES_ROOT_SIZE */
     SECTNUM nSect;
     while ( i < vol->bitmap.size &&
@@ -146,7 +146,8 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
             adfFreeBitmap(vol);
             return rc;
         }
-        j++; i++;
+        j++;
+        i++;
     }
 
     /* check for erratic (?) (non-zero) entries in bmpages beyond the expected size,
@@ -188,7 +189,7 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
         for ( uint32_t i2 = i ; i2 < BM_PAGES_EXT_SIZE ; i2++ ) {
             if ( bmExt.bmPages[i2] != 0 )
                 adfEnv.wFct (
-                    "adfReadBitmap: a non-zero (%u, 0x%02x) entry in bm ext. block %d"
+                    "adfReadBitmap: a non-zero (%u, 0x%02x) entry in bm ext. block %d "
                     "bmpage[%u] in a volume with bmpage size %d",
                     nSect, bmExt.bmPages[i2], bmExt.bmPages[i2], i2, vol->bitmap.size );
         }

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -590,7 +590,7 @@ BOOL adfGetFreeBlocks ( struct AdfVolume * const vol,
  */
 RETCODE adfCreateBitmap ( struct AdfVolume * const vol )
 {
-    SECTNUM nBlock = vol->lastBlock - vol->firstBlock + 1 - 2;
+    SECTNUM nBlock = (SECTNUM) adfVolGetBlockNumWithoutBootblock ( vol );
 
     vol->bitmap.size = nBlock2bitmapSize ( (uint32_t) nBlock );
     RETCODE rc = adfBitmapAllocate ( vol );
@@ -823,8 +823,8 @@ void adfFreeBitmap ( struct AdfVolume * const vol )
  */
 RETCODE adfBitmapAllocate ( struct AdfVolume * const vol )
 {
-    uint32_t nBlock = (uint32_t) ( vol->lastBlock - vol->firstBlock + 1 - 2 );
-    vol->bitmap.size = nBlock2bitmapSize ( nBlock );
+    vol->bitmap.size = nBlock2bitmapSize (
+        adfVolGetBlockNumWithoutBootblock ( vol ) );
 
     vol->bitmap.table = (struct bBitmapBlock**)
         malloc ( sizeof(struct bBitmapBlock *) * vol->bitmap.size );

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -321,22 +321,17 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
         return rc;
     }
 
-    struct AdfEntry rootEntry;
-    rc = adfEntBlock2Entry ( (struct bEntryBlock *) &rootDirBlock, &rootEntry );
-    if ( rc != RC_OK )
-        return rc;
-    if ( ! isDirEmpty ( (const struct bDirBlock * const) &rootEntry) ) {
+    if ( ! isDirEmpty ( (const struct bDirBlock * const) &rootDirBlock) ) {
         // note: for a large volume (a hard disk) getting all entries can become big
         // - it may need to be optimized
         struct AdfList * const entries = adfGetRDirEnt ( vol, vol->rootBlock, TRUE );
         if ( entries == NULL ) {
             return RC_ERROR;
         }
+
         adfBitmapListSetUsed ( vol, entries );
         adfFreeDirList ( entries );
     }
-    free ( rootEntry.name );
-    rootEntry.name = NULL;
 
     // directory cache blocks? (TO CHECK!)
     //  -> done above (in adfBitmapListSetUsed() )
@@ -359,6 +354,7 @@ static RETCODE adfBitmapListSetUsed ( struct AdfVolume * const     vol,
             (const struct AdfEntry * const) cell->content;
 
         // mark entry block
+        // (all header blocks (file, dir, links) are done with this)
         adfSetBlockUsed ( vol, entry->sector );
 
         // mark file blocks

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -162,10 +162,10 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
         return rc;
 
     struct bBitmapExtBlock bmExt;
-    nSect = root->bmExt;
-    while ( nSect != 0 ) {
+    SECTNUM bmExtSect = root->bmExt;
+    while ( bmExtSect != 0 ) {
         /* bitmap pointers in bitmapExtBlock, j <= mapSize */
-        rc = adfReadBitmapExtBlock ( vol, nSect, &bmExt );
+        rc = adfReadBitmapExtBlock ( vol, bmExtSect, &bmExt );
         if ( rc != RC_OK ) {
             adfFreeBitmap(vol);
             return rc;
@@ -194,10 +194,10 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
                 adfEnv.wFct (
                     "adfReadBitmap: a non-zero (%u, 0x%02x) entry in bm ext. block %d "
                     "bmpage[%u] in a volume with bmpage size %d",
-                    nSect, bmExt.bmPages[i2], bmExt.bmPages[i2], i2, vol->bitmap.size );
+                    bmExtSect, bmExt.bmPages[i2], bmExt.bmPages[i2], i2, vol->bitmap.size );
         }
 
-        nSect = bmExt.nextBlock;
+        bmExtSect = bmExt.nextBlock;
     }
 
     return rc;

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -151,6 +151,41 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
         i++;
     }
 
+    /* state validity checks */
+    assert ( i <= BM_PAGES_ROOT_SIZE );
+
+    assert ( ( i < vol->bitmap.size &&
+               root->bmPages[i] != 0 ) ||
+             ( i == vol->bitmap.size ) );
+
+    // some images fail on this, https://github.com/lclevy/ADFlib/issues/63
+    //   assert ( ( i == vol->bitmap.size && root->bmPages[i] == 0 ) ||
+    //            ( i < vol->bitmap.size ) );
+
+    assert ( ( i < vol->bitmap.size &&
+               root->bmExt != 0 ) ||
+             ( i == vol->bitmap.size ) );
+
+    assert ( ( i == vol->bitmap.size &&
+               root->bmExt == 0 ) ||
+             ( i < vol->bitmap.size ) );
+
+    if  ( i < vol->bitmap.size  &&  root->bmPages[i] == 0 ) {
+        adfEnv.eFct ( "adfReadBitmap: root bmpages[%u] == 0, "
+                      "but vol. %s should have %u bm sectors",
+                      i, vol->volName, vol->bitmap.size );
+        adfFreeBitmap ( vol );
+        return RC_ERROR;
+    }
+
+    if ( i < vol->bitmap.size  &&  root->bmExt == 0 ) {
+        adfEnv.eFct ( "adfReadBitmap: read %u of %u from root bm sectors of "
+                      "%u total to read, but root->bmExt is 0",
+                      i, BM_PAGES_ROOT_SIZE, vol->bitmap.size );
+        adfFreeBitmap ( vol );
+        return RC_ERROR;
+    }
+
     /* check for erratic (?) (non-zero) entries in bmpages beyond the expected size,
        more info:  https://github.com/lclevy/ADFlib/issues/63 */
     for ( uint32_t i2 = i ; i2 < BM_PAGES_ROOT_SIZE ; i2++ ) {

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -129,18 +129,18 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
     uint32_t j = 0,
              i = 0;
     /* bitmap pointers in rootblock : 0 <= i < BM_PAGES_ROOT_SIZE */
-    SECTNUM nSect;
+    SECTNUM bmSect;
     while ( i < vol->bitmap.size &&
             i < BM_PAGES_ROOT_SIZE &&
             root->bmPages[i] != 0 )
     {
-        vol->bitmap.blocks[j] = nSect = root->bmPages[i];
-        if ( ! isSectNumValid ( vol, nSect ) ) {
-            adfEnv.wFct ( "adfReadBitmap : sector %d out of range", nSect );
+        vol->bitmap.blocks[j] = bmSect = root->bmPages[i];
+        if ( ! isSectNumValid ( vol, bmSect ) ) {
+            adfEnv.wFct ( "adfReadBitmap : sector %d out of range", bmSect );
             // abort here?
         }
 
-        rc = adfReadBitmapBlock ( vol, nSect, vol->bitmap.table[j] );
+        rc = adfReadBitmapBlock ( vol, bmSect, vol->bitmap.table[j] );
         if ( rc != RC_OK ) {
             adfFreeBitmap(vol);
             return rc;
@@ -172,14 +172,14 @@ RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
         }
         i=0;
         while ( i < BM_PAGES_EXT_SIZE && j < vol->bitmap.size ) {
-            SECTNUM nSect = bmExt.bmPages[i];
-            if ( ! isSectNumValid ( vol, nSect ) ) {
-                adfEnv.wFct ( "adfReadBitmap : sector %d out of range", nSect );
+            bmSect = bmExt.bmPages[i];
+            if ( ! isSectNumValid ( vol, bmSect ) ) {
+                adfEnv.wFct ( "adfReadBitmap : sector %d out of range", bmSect );
                 return RC_ERROR;
             }
-            vol->bitmap.blocks[j] = nSect;
+            vol->bitmap.blocks[j] = bmSect;
 
-            rc = adfReadBitmapBlock ( vol, nSect, vol->bitmap.table[j] );
+            rc = adfReadBitmapBlock ( vol, bmSect, vol->bitmap.table[j] );
             if ( rc != RC_OK ) {
                 adfFreeBitmap(vol);
                 return rc;

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -277,14 +277,16 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
     uint32_t i = 0,
              j = 0;
     /* bitmap pointers in rootblock : 0 <= i < BM_PAGES_ROOT_SIZE */
-    SECTNUM nSect;
+    SECTNUM bmSect;
     while ( i < vol->bitmap.size &&
             i < BM_PAGES_ROOT_SIZE &&
             root->bmPages[i] != 0 )
     {
-        vol->bitmap.blocks[j] = nSect = root->bmPages[i];
-        if ( ! isSectNumValid ( vol, nSect ) ) {
-            adfEnv.wFct ( "adfReadBitmap : sector %d out of range", nSect );
+        vol->bitmap.blocks[j] = bmSect = root->bmPages[i];
+        if ( ! isSectNumValid ( vol, bmSect ) ) {
+            adfEnv.wFct ( "adfReconstructBitmap: sector %d out of range, root bm[%u]",
+                          bmSect, i );
+            adfFreeBitmap ( vol );
             return RC_ERROR;
         }
 
@@ -380,9 +382,9 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
                 adfEnv.wFct (
                     "adfReadBitmap: a non-zero (%u, 0x%02x) entry in bm ext. block %d"
                     "bmpage[%u] in a volume with bmpage size %d",
-                    nSect,
                     bmExtBlock.bmPages[i2],
                     bmExtBlock.bmPages[i2],
+                    bmExtSect,
                     i2, vol->bitmap.size );
         }
 

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -713,7 +713,8 @@ RETCODE adfReadBitmapBlock ( struct AdfVolume *    vol,
 #endif
 
     if ( bitm->checkSum != adfNormalSum ( buf, 0, LOGICAL_BLOCK_SIZE ) ) {
-        adfEnv.wFct("adfReadBitmapBlock : invalid checksum");
+        adfEnv.wFct ( "adfReadBitmapBlock : invalid checksum, volume '%s', block %u",
+                      vol->volName, nSect );
         // return error here?
     }
 

--- a/src/adf_bitm.c
+++ b/src/adf_bitm.c
@@ -262,12 +262,12 @@ RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
         }
         i=0;
         while ( i < BM_PAGES_EXT_SIZE && j < vol->bitmap.size ) {
-            nSect = bmExtBlock.bmPages[i];
-            if ( ! isSectNumValid ( vol, nSect ) ) {
-                adfEnv.wFct ( "adfReadBitmap : sector %d out of range", nSect );
+            SECTNUM bmBlkPtr = bmExtBlock.bmPages[i];
+            if ( ! isSectNumValid ( vol, bmBlkPtr ) ) {
+                adfEnv.wFct ( "adfReadBitmap : sector %d out of range", bmBlkPtr );
                 // abort here?
             }
-            vol->bitmap.blocks[j] = nSect;
+            vol->bitmap.blocks[j] = bmBlkPtr;
 
             //rc = adfReadBitmapBlock ( vol, nSect, vol->bitmapTable[j] );
             //if ( rc != RC_OK ) {

--- a/src/adf_bitm.h
+++ b/src/adf_bitm.h
@@ -51,7 +51,7 @@ PREFIX RETCODE adfWriteBitmapExtBlock ( struct AdfVolume * const             vol
                                         const struct bBitmapExtBlock * const bitme );
 
 SECTNUM adfGet1FreeBlock ( struct AdfVolume * const vol );
-RETCODE adfUpdateBitmap ( struct AdfVolume * const vol );
+PREFIX RETCODE adfUpdateBitmap ( struct AdfVolume * const vol );
 PREFIX uint32_t adfCountFreeBlocks ( const struct AdfVolume * const vol );
 
 RETCODE adfReadBitmap ( struct AdfVolume * const        vol,

--- a/src/adf_bitm.h
+++ b/src/adf_bitm.h
@@ -34,21 +34,21 @@
 #include "prefix.h"
 
 
-RETCODE adfReadBitmapBlock ( struct AdfVolume * const    vol,
-                             const SECTNUM               nSect,
-                             struct bBitmapBlock * const bitm );
+PREFIX RETCODE adfReadBitmapBlock ( struct AdfVolume * const    vol,
+                                    const SECTNUM               nSect,
+                                    struct bBitmapBlock * const bitm );
 
-RETCODE adfWriteBitmapBlock ( struct AdfVolume * const          vol,
-                              const SECTNUM                     nSect,
-                              const struct bBitmapBlock * const bitm );
+PREFIX RETCODE adfWriteBitmapBlock ( struct AdfVolume * const          vol,
+                                     const SECTNUM                     nSect,
+                                     const struct bBitmapBlock * const bitm );
 
-RETCODE adfReadBitmapExtBlock ( struct AdfVolume * const       vol,
-                                const SECTNUM                  nSect,
-                                struct bBitmapExtBlock * const bitme );
+PREFIX RETCODE adfReadBitmapExtBlock ( struct AdfVolume * const       vol,
+                                       const SECTNUM                  nSect,
+                                       struct bBitmapExtBlock * const bitme );
 
-RETCODE adfWriteBitmapExtBlock ( struct AdfVolume * const             vol,
-                                 const SECTNUM                        nSect,
-                                 const struct bBitmapExtBlock * const bitme );
+PREFIX RETCODE adfWriteBitmapExtBlock ( struct AdfVolume * const             vol,
+                                        const SECTNUM                        nSect,
+                                        const struct bBitmapExtBlock * const bitme );
 
 SECTNUM adfGet1FreeBlock ( struct AdfVolume * const vol );
 RETCODE adfUpdateBitmap ( struct AdfVolume * const vol );
@@ -57,8 +57,8 @@ PREFIX uint32_t adfCountFreeBlocks ( const struct AdfVolume * const vol );
 RETCODE adfReadBitmap ( struct AdfVolume * const        vol,
                         const struct bRootBlock * const root );
 
-RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
-                               const struct bRootBlock * const root );
+PREFIX RETCODE adfReconstructBitmap ( struct AdfVolume * const        vol,
+                                      const struct bRootBlock * const root );
 
 BOOL adfIsBlockFree ( const struct AdfVolume * const vol,
                       const SECTNUM            nSect );
@@ -77,7 +77,7 @@ RETCODE adfCreateBitmap ( struct AdfVolume * const vol );
 RETCODE adfWriteNewBitmap ( struct AdfVolume * const vol );
 
 RETCODE adfBitmapAllocate ( struct AdfVolume * const vol );
-void adfFreeBitmap ( struct AdfVolume * const vol );
+PREFIX void adfFreeBitmap ( struct AdfVolume * const vol );
 
 #endif /* ADF_BITM_H */
 

--- a/src/adf_cache.c
+++ b/src/adf_cache.c
@@ -632,11 +632,14 @@ RETCODE adfReadDirCBlock ( struct AdfVolume * const      vol,
     swapEndian((uint8_t*)dirc,SWBL_CACHE);
 #endif
     if (dirc->checkSum!=adfNormalSum(buf,20,512))
-        (*adfEnv.wFct)("adfReadDirCBlock : invalid checksum");
+        adfEnv.wFct ( "adfReadDirCBlock : invalid checksum, volume '%s', block %u",
+                      vol->volName, nSect );
     if (dirc->type!=T_DIRC)
-        (*adfEnv.wFct)("adfReadDirCBlock : T_DIRC not found");
+        adfEnv.wFct ( "adfReadDirCBlock : T_DIRC not found, volume '%s', block %u",
+                      vol->volName, nSect );
     if (dirc->headerKey!=nSect)
-        (*adfEnv.wFct)("adfReadDirCBlock : headerKey!=nSect");
+        adfEnv.wFct ( "adfReadDirCBlock : headerKey (%u) != nSect (%u), volume '%s', block %u",
+            dirc->headerKey, nSect, vol->volName, nSect );
 
     return RC_OK;
 }

--- a/src/adf_dev.c
+++ b/src/adf_dev.c
@@ -52,8 +52,8 @@
  *          IF UNSURE USE adfMountDev() FIRST TO CHECK IF FILESYSTEM STRUCTURES
  *          EXIST ALREADY ON THE DEVICE(!)
  */
-struct AdfDevice * adfOpenDev ( const char * const filename,
-                                const BOOL         ro )
+struct AdfDevice * adfOpenDev ( const char * const  filename,
+                                const AdfAccessMode mode )
 {
     struct AdfDevice * dev = ( struct AdfDevice * )
         malloc ( sizeof ( struct AdfDevice ) );
@@ -62,7 +62,7 @@ struct AdfDevice * adfOpenDev ( const char * const filename,
         return NULL;
     }
 
-    dev->readOnly = ro;
+    dev->readOnly = ( mode != ADF_ACCESS_MODE_READWRITE );
 
     /* switch between dump files and real devices */
     struct AdfNativeFunctions * nFct = adfEnv.nativeFct;
@@ -70,9 +70,9 @@ struct AdfDevice * adfOpenDev ( const char * const filename,
 
     RETCODE rc;
     if ( dev->isNativeDev )
-        rc = ( *nFct->adfInitDevice )( dev, filename, ro );
+        rc = nFct->adfInitDevice ( dev, filename, mode );
     else
-        rc = adfInitDumpDevice ( dev, filename, ro );
+        rc = adfInitDumpDevice ( dev, filename, mode );
     if ( rc != RC_OK ) {
         ( *adfEnv.eFct )( "adfOpenDev : device init error" );
         free ( dev );
@@ -228,13 +228,13 @@ void adfDeviceInfo ( struct AdfDevice * dev )
  *
  * adfInitDevice() must fill dev->size !
  */
-struct AdfDevice * adfMountDev ( const char * const filename,
-                                 const BOOL         ro )
+struct AdfDevice * adfMountDev ( const char * const  filename,
+                                 const AdfAccessMode mode )
 {
     RETCODE rc;
     uint8_t buf[512];
 
-    struct AdfDevice * dev = adfOpenDev ( filename, ro );
+    struct AdfDevice * dev = adfOpenDev ( filename, mode );
     if ( ! dev ) {
         //(*adfEnv.eFct)("adfMountDev : malloc error");
         return NULL;

--- a/src/adf_dev.h
+++ b/src/adf_dev.h
@@ -43,15 +43,15 @@ struct AdfDevice {
 };
 
 
-PREFIX struct AdfDevice * adfOpenDev ( const char * const filename,
-                                       const BOOL         ro );
+PREFIX struct AdfDevice * adfOpenDev ( const char * const  filename,
+                                       const AdfAccessMode mode );
 PREFIX void adfCloseDev ( struct AdfDevice * const dev );
 
 PREFIX int adfDevType ( struct AdfDevice * dev );
 PREFIX void adfDeviceInfo ( struct AdfDevice * dev );
 
-PREFIX struct AdfDevice * adfMountDev ( const char * const filename,
-                                        const BOOL         ro );
+PREFIX struct AdfDevice * adfMountDev ( const char * const  filename,
+                                        const AdfAccessMode mode );
 PREFIX void adfUnMountDev ( struct AdfDevice * const dev );
 
 //struct AdfDevice* adfCreateDev(char* filename, int32_t cylinders, int32_t heads, int32_t sectors);

--- a/src/adf_dev_dump.c
+++ b/src/adf_dev_dump.c
@@ -42,11 +42,11 @@
  */
 RETCODE adfInitDumpDevice ( struct AdfDevice * const dev,
                             const char * const       name,
-                            const BOOL               ro )
+                            const AdfAccessMode      mode )
 {
-    dev->readOnly = ro;
+    dev->readOnly = ( mode != ADF_ACCESS_MODE_READWRITE );
     errno = 0;
-    if (!ro) {
+    if ( ! dev->readOnly ) {
         dev->fd = fopen ( name, "rb+" );
         /* force read only */
         if ( ! dev->fd && ( errno == EACCES || errno == EROFS ) ) {

--- a/src/adf_dev_dump.h
+++ b/src/adf_dev_dump.h
@@ -40,7 +40,7 @@ PREFIX RETCODE adfCreateHdFile ( struct AdfDevice * const dev,
 
 RETCODE adfInitDumpDevice ( struct AdfDevice * const dev,
                             const char * const       name,
-                            const BOOL               ro );
+                            const AdfAccessMode      mode );
 
 RETCODE adfReadDumpSector ( struct AdfDevice * const dev,
                             const uint32_t           n,

--- a/src/adf_dev_flop.c
+++ b/src/adf_dev_flop.c
@@ -65,7 +65,7 @@ RETCODE adfMountFlop ( struct AdfDevice * const dev )
     vol->mounted = TRUE;
     vol->firstBlock = 0;
     vol->lastBlock = (int32_t) ( dev->cylinders * dev->heads * dev->sectors - 1 );
-    vol->rootBlock = (vol->lastBlock+1 - vol->firstBlock)/2;
+    vol->rootBlock = adfVolCalcRootBlk ( vol );
     vol->blockSize = 512;
     vol->dev = dev;
  

--- a/src/adf_dev_hd.c
+++ b/src/adf_dev_hd.c
@@ -174,7 +174,7 @@ RETCODE adfMountHd ( struct AdfDevice * const dev )
 
         vol->firstBlock = (int32_t) rdsk.cylBlocks * part.lowCyl;
         vol->lastBlock = ( part.highCyl + 1 ) * (int32_t) rdsk.cylBlocks - 1;
-        vol->rootBlock = (vol->lastBlock - vol->firstBlock+1)/2;
+        vol->rootBlock = adfVolCalcRootBlk ( vol );
         vol->blockSize = part.blockSize*4;
 
         len = (unsigned) min ( 31, part.nameLen );

--- a/src/adf_dir.c
+++ b/src/adf_dir.c
@@ -1127,19 +1127,26 @@ RETCODE adfReadEntryBlock ( struct AdfVolume * const   vol,
 #endif
 /*printf("readentry=%d\n",nSect);*/
     if (ent->checkSum!=adfNormalSum((uint8_t*)buf,20,512)) {
-        (*adfEnv.wFct)("adfReadEntryBlock : invalid checksum");
+        adfEnv.wFct ( "adfReadEntryBlock : invalid checksum, volume '%s', block %u",
+                      vol->volName, nSect );
         return RC_BLOCKSUM;
     }
     if (ent->type!=T_HEADER) {
-        (*adfEnv.wFct)("adfReadEntryBlock : T_HEADER id not found");
+        adfEnv.wFct ( "adfReadEntryBlock : T_HEADER id not found, volume '%s', block %u",
+                      vol->volName, nSect );
         return RC_ERROR;
     }
-    if ( ent->nameLen > MAXNAMELEN ||
-         ent->commLen > MAXCMMTLEN )
-    {
-        (*adfEnv.wFct)("adfReadEntryBlock : nameLen or commLen incorrect"); 
-        printf("nameLen=%d, commLen=%d, name=%s sector%d\n",
-            ent->nameLen,ent->commLen,ent->name, ent->headerKey);
+    if ( ent->nameLen > MAXNAMELEN ) {
+        adfEnv.wFct ( "adfReadEntryBlock : nameLen (%d) incorrect, volume '%s', block %u, entry %s",
+                      ent->nameLen, vol->volName, nSect, ent->name );
+        //printf("nameLen=%d, commLen=%d, name=%s sector%d\n",
+        //    ent->nameLen,ent->commLen,ent->name, ent->headerKey);
+    }
+    if ( ent->commLen > MAXCMMTLEN ) {
+        adfEnv.wFct ( "adfReadEntryBlock : commLen (%d) incorrect, volume '%s', block %u, entry %s",
+                      ent->commLen, vol->volName, nSect, ent->name);
+        //printf("nameLen=%d, commLen=%d, name=%s sector%d\n",
+        //    ent->nameLen, ent->commLen, ent->name, ent->headerKey);
     }
 
     return RC_OK;

--- a/src/adf_env.h
+++ b/src/adf_env.h
@@ -82,7 +82,7 @@ PREFIX void adfChgEnvProp(int prop, void *new);
 PREFIX char* adfGetVersionNumber();
 PREFIX char* adfGetVersionDate();
 
-extern struct AdfEnv adfEnv;
+PREFIX extern struct AdfEnv adfEnv;
 
 #endif /* ADF_ENV_H */
 /*##########################################################################*/

--- a/src/adf_nativ.h
+++ b/src/adf_nativ.h
@@ -31,7 +31,7 @@ struct AdfNativeFunctions {
     /* called by adfMount() */
     RETCODE (*adfInitDevice)( struct AdfDevice * const dev,
                               const char * const       name,
-                              const BOOL               ro );
+                              const AdfAccessMode      mode );
 
     /* called by adfUnMount() */
     RETCODE (*adfReleaseDevice)(struct AdfDevice * const dev);

--- a/src/adf_types.h
+++ b/src/adf_types.h
@@ -36,4 +36,9 @@ typedef int      BOOL;
 #define TRUE    1
 #define FALSE   0
 
+typedef enum {
+    ADF_ACCESS_MODE_READWRITE = 0,
+    ADF_ACCESS_MODE_READONLY  = 1
+} AdfAccessMode;
+
 #endif

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -278,12 +278,14 @@ PREFIX RETCODE adfRemountReadWrite ( struct AdfVolume * vol )
 
     // the volume's bitmap could have been rebuilt in memory,
     // write it to the volume when entering read-write mode
+    /*
     vol->readOnly = FALSE;
     RETCODE rc = adfUpdateBitmap ( vol );
     if ( rc != RC_OK ) {
         vol->readOnly = TRUE;
         return rc;
     }
+    */
 
     vol->readOnly = FALSE;
     return RC_OK;

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -444,21 +444,6 @@ printf("%3d %x, ",i,vol->bitmapTable[0]->map[i]);
     return(vol);
 }
 
-/*
-RETCODE adfVolReconstructBitmap ( struct AdfVolume * const vol )
-{
-    struct bRootBlock root;
-    //printf ("reading root block from %u\n", vol->rootBlock );
-    RETCODE rc = adfReadRootBlock ( vol, (uint32_t) vol->rootBlock, &root );
-    if ( rc != RC_OK ) {
-        adfEnv.eFct ( "adfVolReconstructBitmap : invalid RootBlock, sector %u",
-                      vol->rootBlock );
-        return rc;
-    }
-    //printf ("root block read, name %s\n", root.diskName );
-    return adfReconstructBitmap ( vol, &root );
-}
-*/
 
 /*-----*/
 

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -213,24 +213,27 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
 
     RETCODE rc = adfBitmapAllocate ( vol );
     if ( rc != RC_OK ) {
-            adfEnv.wFct ( "adfMount : adfBitmapAllocate() returned error %d, "
-                          "mounting read-only (failsafe)", rc );
-            vol->readOnly = TRUE;
+            adfEnv.eFct ( "adfMount : adfBitmapAllocate() returned error %d, "
+                          "mounting volume %s failed", rc, vol->volName );
+            adfUnMount ( vol );
+            return NULL;
     } else if ( root.bmFlag == BM_VALID ||
                 vol->readOnly == TRUE )
     {
         rc = adfReadBitmap ( vol, &root );
         if ( rc != RC_OK ) {
-            adfEnv.wFct ( "adfMount : adfReadBitmap() returned error %d, "
-                          "mounting read-only (failsafe)", rc );
-            vol->readOnly = TRUE;
+            adfEnv.eFct ( "adfMount : adfReadBitmap() returned error %d, "
+                          "mounting volume %s failed", rc, vol->volName );
+            adfUnMount ( vol );
+            return NULL;
         }
     } else {
         rc = adfReconstructBitmap ( vol, &root );
         if ( rc != RC_OK ) {
-            adfEnv.wFct ( "adfMount : adfReconstructBitmap() returned error %d, "
-                          "mounting read-only (failsafe)", rc );
-            vol->readOnly = TRUE;
+            adfEnv.eFct ( "adfMount : adfReconstructBitmap() returned error %d, "
+                          "mounting volume %s failed", rc, vol->volName );
+            adfUnMount ( vol );
+            return NULL;
         }
     }
 

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -170,7 +170,7 @@ void adfVolumeInfo ( struct AdfVolume * const vol )
  */
 PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
                                      const int                nPart,
-                                     const BOOL               readOnly )
+                                     const AdfAccessMode      mode )
 {
     struct bRootBlock root;
     struct bBootBlock boot;
@@ -203,7 +203,7 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
     if (dev->readOnly /*|| isDIRCACHE(vol->dosType)*/)
         vol->readOnly = TRUE;
     else
-        vol->readOnly = readOnly;
+        vol->readOnly = ( mode != ADF_ACCESS_MODE_READWRITE );
 	   	
     if ( adfReadRootBlock ( vol, (uint32_t) vol->rootBlock, &root ) != RC_OK ) {
         adfEnv.eFct ( "adfMount : invalid RootBlock, sector %u", vol->rootBlock );

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -440,7 +440,7 @@ printf("%3d %x, ",i,vol->bitmapTable[0]->map[i]);
     return(vol);
 }
 
-
+/*
 RETCODE adfVolReconstructBitmap ( struct AdfVolume * const vol )
 {
     struct bRootBlock root;
@@ -454,7 +454,7 @@ RETCODE adfVolReconstructBitmap ( struct AdfVolume * const vol )
     //printf ("root block read, name %s\n", root.diskName );
     return adfReconstructBitmap ( vol, &root );
 }
-
+*/
 
 /*-----*/
 

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -216,7 +216,9 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
             adfEnv.wFct ( "adfMount : adfBitmapAllocate() returned error %d, "
                           "mounting read-only (failsafe)", rc );
             vol->readOnly = TRUE;
-    } else if ( root.bmFlag == BM_VALID ) {
+    } else if ( root.bmFlag == BM_VALID ||
+                vol->readOnly == TRUE )
+    {
         rc = adfReadBitmap ( vol, &root );
         if ( rc != RC_OK ) {
             adfEnv.wFct ( "adfMount : adfReadBitmap() returned error %d, "

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -176,8 +176,22 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
     struct bBootBlock boot;
     struct AdfVolume * vol;
 
-    if (dev==NULL || nPart >= dev->nVol) {
-        (*adfEnv.eFct)("adfMount : invalid parameter(s)");
+    if ( dev == NULL ) {
+        adfEnv.eFct ( "adfMount : invalid device (NULL)" );
+        return NULL;
+    }
+
+    if ( nPart < 0  ||
+         nPart >= dev->nVol )
+    {
+        adfEnv.eFct ( "adfMount : invalid partition %d", nPart );
+        return NULL;
+    }
+
+    if ( mode != ADF_ACCESS_MODE_READONLY  &&
+         mode != ADF_ACCESS_MODE_READWRITE )
+    {
+        adfEnv.eFct ( "adfMount : invalid mode %d", mode );
         return NULL;
     }
 

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -227,6 +227,7 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
         return NULL;
     }
 
+    /*
     if ( root.bmFlag != BM_VALID ) {
         if ( vol->readOnly == TRUE ) {
             rc = adfReconstructBitmap ( vol, &root );
@@ -243,6 +244,7 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
             return NULL;
         }
     }
+    */
 
     vol->curDirPtr = vol->rootBlock;
 

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -217,21 +217,28 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
                           "mounting volume %s failed", rc, vol->volName );
             adfUnMount ( vol );
             return NULL;
-    } else if ( root.bmFlag == BM_VALID ||
-                vol->readOnly == TRUE )
-    {
-        rc = adfReadBitmap ( vol, &root );
-        if ( rc != RC_OK ) {
-            adfEnv.eFct ( "adfMount : adfReadBitmap() returned error %d, "
-                          "mounting volume %s failed", rc, vol->volName );
-            adfUnMount ( vol );
-            return NULL;
-        }
-    } else {
-        rc = adfReconstructBitmap ( vol, &root );
-        if ( rc != RC_OK ) {
-            adfEnv.eFct ( "adfMount : adfReconstructBitmap() returned error %d, "
-                          "mounting volume %s failed", rc, vol->volName );
+    }
+
+    rc = adfReadBitmap ( vol, &root );
+    if ( rc != RC_OK ) {
+        adfEnv.eFct ( "adfMount : adfReadBitmap() returned error %d, "
+                      "mounting volume %s failed", rc, vol->volName );
+        adfUnMount ( vol );
+        return NULL;
+    }
+
+    if ( root.bmFlag != BM_VALID ) {
+        if ( vol->readOnly == TRUE ) {
+            rc = adfReconstructBitmap ( vol, &root );
+            if ( rc != RC_OK ) {
+                adfEnv.eFct ( "adfMount : adfReconstructBitmap() returned error %d, "
+                              "mounting volume %s failed", rc, vol->volName );
+                adfUnMount ( vol );
+                return NULL;
+            }
+        } else {
+            adfEnv.eFct ( "adfMount : block allocation bitmap marked invalid in root block, "
+                          "mounting the volume %s read-write not possible", vol->volName );
             adfUnMount ( vol );
             return NULL;
         }

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -253,6 +253,43 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
 
 
 /*
+ * adfRemountReadWrite
+ *
+ *
+ */
+PREFIX RETCODE adfRemountReadWrite ( struct AdfVolume * vol )
+{
+    if ( vol == NULL )
+        return RC_ERROR;
+
+    if ( vol->readOnly == FALSE ) {
+        adfEnv.wFct ( "adfRemountReadWrite : volume %s already mounted read-write",
+                      vol->volName );
+        return RC_OK;
+    }
+
+    if ( vol->dev->readOnly ) {
+        adfEnv.eFct ( "adfRemountReadWrite : device read-only, "
+                      "cannot mount %s read-write", vol->volName );
+        return RC_ERROR;
+    }
+
+    // the volume's bitmap could have been rebuilt in memory,
+    // write it to the volume when entering read-write mode
+    vol->readOnly = FALSE;
+    RETCODE rc = adfUpdateBitmap ( vol );
+    if ( rc != RC_OK ) {
+        vol->readOnly = TRUE;
+        return rc;
+    }
+
+    vol->readOnly = FALSE;
+    return RC_OK;
+}
+
+
+
+/*
 *
 * adfUnMount
 *

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -259,35 +259,29 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
  *
  *
  */
-PREFIX RETCODE adfRemountReadWrite ( struct AdfVolume * vol )
+PREFIX RETCODE adfRemount ( struct AdfVolume *  vol,
+                            const AdfAccessMode mode )
 {
     if ( vol == NULL )
         return RC_ERROR;
 
-    if ( vol->readOnly == FALSE ) {
-        adfEnv.wFct ( "adfRemountReadWrite : volume %s already mounted read-write",
-                      vol->volName );
-        return RC_OK;
-    }
+    if ( ! vol->mounted )
+        return RC_ERROR;
 
-    if ( vol->dev->readOnly ) {
-        adfEnv.eFct ( "adfRemountReadWrite : device read-only, "
-                      "cannot mount %s read-write", vol->volName );
+    if ( mode == ADF_ACCESS_MODE_READWRITE ) {
+        if ( vol->dev->readOnly ) {
+            adfEnv.eFct ( "adfRemount : device read-only, cannot mount "
+                          "volume '%s' read-write", vol->volName );
+            return RC_ERROR;
+        }
+        vol->readOnly = FALSE;
+    } else if ( mode == ADF_ACCESS_MODE_READONLY ) {
+        vol->readOnly = TRUE;
+    } else {
+        adfEnv.eFct ( "adfRemount : cannot remount volume %s, invalid mode %d",
+                      vol->volName, mode );
         return RC_ERROR;
     }
-
-    // the volume's bitmap could have been rebuilt in memory,
-    // write it to the volume when entering read-write mode
-    /*
-    vol->readOnly = FALSE;
-    RETCODE rc = adfUpdateBitmap ( vol );
-    if ( rc != RC_OK ) {
-        vol->readOnly = TRUE;
-        return rc;
-    }
-    */
-
-    vol->readOnly = FALSE;
     return RC_OK;
 }
 

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -293,7 +293,8 @@ struct AdfVolume * adfCreateVol ( struct AdfDevice * const dev,
     vol->dev = dev;
     vol->firstBlock = (int32_t) ( dev->heads * dev->sectors * start );
     vol->lastBlock = vol->firstBlock + (int32_t) ( dev->heads * dev->sectors * len ) - 1;
-    vol->rootBlock = ( vol->lastBlock - vol->firstBlock + 1 ) / 2;
+    vol->rootBlock = adfVolCalcRootBlk ( vol );
+
 /*printf("first=%ld last=%ld root=%ld\n",vol->firstBlock,
  vol->lastBlock, vol->rootBlock);
 */

--- a/src/adf_vol.c
+++ b/src/adf_vol.c
@@ -259,6 +259,8 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
         }
     }
     */
+    if ( root.bmFlag != BM_VALID )
+        adfEnv.wFct ( "adfMount : invalid bitmap on volume '%s'", vol->volName );
 
     vol->curDirPtr = vol->rootBlock;
 

--- a/src/adf_vol.h
+++ b/src/adf_vol.h
@@ -90,6 +90,8 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
                                      const int                nPart,
                                      const AdfAccessMode      mode );
 
+PREFIX RETCODE adfRemountReadWrite ( struct AdfVolume * vol );
+
 PREFIX void adfUnMount ( struct AdfVolume * const vol );
 
 PREFIX void adfVolumeInfo ( struct AdfVolume * const vol );

--- a/src/adf_vol.h
+++ b/src/adf_vol.h
@@ -63,6 +63,17 @@ struct AdfVolume {
     SECTNUM curDirPtr;
 };
 
+static inline uint32_t adfVolGetBlockNumWithoutBootblock (
+    const struct AdfVolume * const vol )
+{
+    return (uint32_t) ( vol->lastBlock - vol->firstBlock + 1 - 2 );
+}
+
+static inline uint32_t adfVolGetBlockNum ( const struct AdfVolume * const vol )
+{
+    return (uint32_t) ( vol->lastBlock - vol->firstBlock + 1 );
+}
+
 
 PREFIX RETCODE adfInstallBootBlock ( struct AdfVolume * const vol,
                                      const uint8_t * const    code );

--- a/src/adf_vol.h
+++ b/src/adf_vol.h
@@ -102,7 +102,7 @@ struct AdfVolume * adfCreateVol ( struct AdfDevice * const dev,
                                   const char * const       volName,
                                   const uint8_t            volType );
 
-PREFIX RETCODE adfVolReconstructBitmap ( struct AdfVolume * const vol );
+//PREFIX RETCODE adfVolReconstructBitmap ( struct AdfVolume * const vol );
 
 /*void adfReadBitmap(struct AdfVolume* , int32_t nBlock, struct bRootBlock* root);
 void adfUpdateBitmap(struct AdfVolume*);

--- a/src/adf_vol.h
+++ b/src/adf_vol.h
@@ -100,7 +100,7 @@ struct AdfVolume * adfCreateVol ( struct AdfDevice * const dev,
                                   const char * const       volName,
                                   const uint8_t            volType );
 
-RETCODE adfVolReconstructBitmap ( struct AdfVolume * const vol );
+PREFIX RETCODE adfVolReconstructBitmap ( struct AdfVolume * const vol );
 
 /*void adfReadBitmap(struct AdfVolume* , int32_t nBlock, struct bRootBlock* root);
 void adfUpdateBitmap(struct AdfVolume*);

--- a/src/adf_vol.h
+++ b/src/adf_vol.h
@@ -102,11 +102,6 @@ struct AdfVolume * adfCreateVol ( struct AdfDevice * const dev,
                                   const char * const       volName,
                                   const uint8_t            volType );
 
-//PREFIX RETCODE adfVolReconstructBitmap ( struct AdfVolume * const vol );
-
-/*void adfReadBitmap(struct AdfVolume* , int32_t nBlock, struct bRootBlock* root);
-void adfUpdateBitmap(struct AdfVolume*);
-*/
 PREFIX RETCODE adfReadBlock ( struct AdfVolume * const vol,
                               const uint32_t           nSect,
                               uint8_t * const          buf );

--- a/src/adf_vol.h
+++ b/src/adf_vol.h
@@ -90,7 +90,8 @@ PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
                                      const int                nPart,
                                      const AdfAccessMode      mode );
 
-PREFIX RETCODE adfRemountReadWrite ( struct AdfVolume * vol );
+PREFIX RETCODE adfRemount ( struct AdfVolume *  vol,
+                            const AdfAccessMode mode );
 
 PREFIX void adfUnMount ( struct AdfVolume * const vol );
 

--- a/src/adf_vol.h
+++ b/src/adf_vol.h
@@ -74,6 +74,11 @@ static inline uint32_t adfVolGetBlockNum ( const struct AdfVolume * const vol )
     return (uint32_t) ( vol->lastBlock - vol->firstBlock + 1 );
 }
 
+static inline SECTNUM adfVolCalcRootBlk ( const struct AdfVolume * const vol )
+{
+    return ( vol->lastBlock - vol->firstBlock + 1 ) / 2;
+}
+
 
 PREFIX RETCODE adfInstallBootBlock ( struct AdfVolume * const vol,
                                      const uint8_t * const    code );

--- a/src/adf_vol.h
+++ b/src/adf_vol.h
@@ -72,7 +72,7 @@ PREFIX BOOL isSectNumValid ( const struct AdfVolume * const vol,
 
 PREFIX struct AdfVolume * adfMount ( struct AdfDevice * const dev,
                                      const int                nPart,
-                                     const BOOL               readOnly );
+                                     const AdfAccessMode      mode );
 
 PREFIX void adfUnMount ( struct AdfVolume * const vol );
 

--- a/src/generic/adf_nativ.c
+++ b/src/generic/adf_nativ.c
@@ -36,9 +36,9 @@
  */
 RETCODE myInitDevice ( struct AdfDevice * const dev,
                        const char * const       name,
-                       const BOOL               ro )
+                       const AdfAccessMode      mode )
 {
-    (void) dev, (void) name, (void) ro;
+    (void) dev, (void) name, (void) mode;
     return RC_ERROR;
 }
 

--- a/src/linux/adf_nativ.c
+++ b/src/linux/adf_nativ.c
@@ -47,7 +47,7 @@ struct AdfNativeDevice {
  */
 static RETCODE adfLinuxInitDevice ( struct AdfDevice * const dev,
                                     const char * const       name,
-                                    const BOOL               ro )
+                                    const AdfAccessMode      mode )
 {
     struct AdfNativeDevice * nDev = ( struct AdfNativeDevice * )
         malloc ( sizeof ( struct AdfNativeDevice ) );
@@ -59,7 +59,7 @@ static RETCODE adfLinuxInitDevice ( struct AdfDevice * const dev,
 
     dev->nativeDev = nDev;
 
-    dev->readOnly = ro;
+    dev->readOnly = ( mode != ADF_ACCESS_MODE_READWRITE );
     if ( ! dev->readOnly ) {
         nDev->fd = open ( name, O_RDWR );
         dev->readOnly = ( nDev->fd < 0 ) ? TRUE : FALSE;

--- a/src/prefix.h
+++ b/src/prefix.h
@@ -31,7 +31,7 @@
 //#ifdef _WIN32
 #ifdef BUILD_DLL
 
-/* define declaration prefix for exporing symbols compiling a DLL library,
+/* define declaration prefix for exporting symbols compiling a DLL library,
    and importing when compiling a client code
 
    more info:

--- a/src/win32/adf_nativ.c
+++ b/src/win32/adf_nativ.c
@@ -47,7 +47,7 @@ static RETCODE Win32ReleaseDevice ( struct AdfDevice * const dev );
 
 static RETCODE Win32InitDevice ( struct AdfDevice * const dev,
                                  const char * const       lpstrName,
-                                 const BOOL               ro )
+                                 const AdfAccessMode      mode )
 {
 	struct AdfNativeDevice * nDev = ( struct AdfNativeDevice * )
             malloc ( sizeof(struct AdfNativeDevice) );

--- a/tests/test_file_append.c
+++ b/tests/test_file_append.c
@@ -41,7 +41,7 @@ void test_file_append ( test_data_t * const tdata )
     ///
 
     // mount the test volume
-    tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     struct AdfVolume * const vol = tdata->vol;
     ck_assert_ptr_nonnull ( vol );
 
@@ -69,7 +69,7 @@ void test_file_append ( test_data_t * const tdata )
 
     // reset volume state (remount)
     adfUnMount ( tdata->vol );
-    tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     const unsigned file_blocks_used_by_empty_file = 1;
@@ -139,7 +139,7 @@ void test_file_append ( test_data_t * const tdata )
 
     // reset volume state (remount)
     adfUnMount ( tdata->vol );
-    tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     ck_assert_int_eq ( free_blocks_before - file_blocks_used_by_empty_file - 1,
@@ -257,7 +257,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);

--- a/tests/test_file_create.c
+++ b/tests/test_file_create.c
@@ -37,7 +37,7 @@ void test_file_create ( test_data_t * const tdata )
     ck_assert_ptr_nonnull ( device );
 
     // mount the test volume
-    tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     struct AdfVolume * const vol    = tdata->vol;
     ck_assert_ptr_nonnull ( vol );
 
@@ -55,7 +55,7 @@ void test_file_create ( test_data_t * const tdata )
 
     // reset volume state (remount)
     adfUnMount ( tdata->vol );
-    tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     const unsigned file_blocks_used_by_empty_file = 1;
@@ -106,7 +106,7 @@ void test_file_create_with_append ( test_data_t * const tdata )
     ck_assert_ptr_nonnull ( device );
 
     // mount the test volume
-    tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     struct AdfVolume * const vol    = tdata->vol;
     ck_assert_ptr_nonnull ( vol );
 
@@ -124,7 +124,7 @@ void test_file_create_with_append ( test_data_t * const tdata )
 
     // reset volume state (remount)
     adfUnMount ( tdata->vol );
-    tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     ck_assert_int_eq ( free_blocks_before,
@@ -261,7 +261,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);

--- a/tests/test_file_overwrite.c
+++ b/tests/test_file_overwrite.c
@@ -43,7 +43,7 @@ void test_file_write ( test_data_t * const tdata )
 
     // mount the test volume
     struct AdfVolume * vol = //tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     ck_assert_ptr_nonnull ( vol );
 
     // check it is an empty floppy disk
@@ -69,7 +69,7 @@ void test_file_write ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     const unsigned file_blocks_used_by_empty_file = 1;
@@ -140,7 +140,7 @@ void test_file_write ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = // tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     ck_assert_int_eq ( free_blocks_before - file_blocks_used_by_empty_file - 1,
@@ -173,7 +173,7 @@ void test_file_write ( test_data_t * const tdata )
     // reset volume state (remount) 
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
 
     ///
@@ -207,7 +207,7 @@ void test_file_write ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = // tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     
     // verify file information (meta-data)
     file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
@@ -315,7 +315,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);

--- a/tests/test_file_overwrite2.c
+++ b/tests/test_file_overwrite2.c
@@ -46,7 +46,7 @@ void test_file_overwrite ( test_data_t * const tdata )
 
     // mount the test volume
     struct AdfVolume * vol = //tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     ck_assert_ptr_nonnull ( vol );
 
     // check it is an empty floppy disk
@@ -69,7 +69,7 @@ void test_file_overwrite ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     const unsigned file_blocks_used_by_empty_file = 1;
@@ -152,7 +152,7 @@ void test_file_overwrite ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     //ck_assert_int_eq ( free_blocks_before - file_blocks_used_by_empty_file -
@@ -197,7 +197,7 @@ void test_file_overwrite ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
 
 
     ///
@@ -244,7 +244,7 @@ void test_file_overwrite ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     
     // verify file information (meta-data)
     file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
@@ -391,7 +391,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);

--- a/tests/test_file_seek.c
+++ b/tests/test_file_seek.c
@@ -47,7 +47,7 @@ void test_file_seek_eof ( test_data_t * const tdata )
 
     // mount the test volume
     struct AdfVolume * vol = // tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     ck_assert_ptr_nonnull ( vol );
 
     // check it is an empty floppy disk
@@ -73,7 +73,7 @@ void test_file_seek_eof ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = // tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     
     // reopen the file
     file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
@@ -255,7 +255,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);

--- a/tests/test_file_seek_after_write.c
+++ b/tests/test_file_seek_after_write.c
@@ -50,7 +50,7 @@ void test_file_seek_after_write ( test_data_t * const tdata )
 
     // mount the test volume
     struct AdfVolume * vol = // tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     ck_assert_ptr_nonnull ( vol );
 
     // check it is an empty floppy disk
@@ -77,7 +77,7 @@ void test_file_seek_after_write ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = // tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // put random data in the buffer
     pattern_random ( buffer, bufsize );
@@ -324,7 +324,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);

--- a/tests/test_file_truncate.c
+++ b/tests/test_file_truncate.c
@@ -49,7 +49,7 @@ void test_file_truncate ( test_data_t * const tdata )
 
     // mount the test volume
     struct AdfVolume * vol = // tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     ck_assert_ptr_nonnull ( vol );
 
     // check it is an empty floppy disk
@@ -71,7 +71,7 @@ void test_file_truncate ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = // tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     const unsigned file_blocks_used_by_empty_file = 1;
@@ -117,7 +117,7 @@ void test_file_truncate ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     //ck_assert_int_eq ( free_blocks_before - file_blocks_used_by_empty_file - 1,
@@ -174,7 +174,7 @@ void test_file_truncate ( test_data_t * const tdata )
 
     // reset volume state (remount)
     adfUnMount ( vol );
-    vol = adfMount ( device, 0, FALSE );
+    vol = adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     
     // check volume metadata after truncating
     ck_assert_int_eq ( 1, adfDirCountEntries ( vol, vol->curDirPtr ) );
@@ -463,7 +463,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);

--- a/tests/test_file_truncate2.c
+++ b/tests/test_file_truncate2.c
@@ -49,7 +49,7 @@ void test_adfFileTruncateGetBlocksToRemove ( test_data_t * const tdata )
 
     // mount the test volume
     struct AdfVolume * vol = // tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
     ck_assert_ptr_nonnull ( vol );
 
     // check it is an empty floppy disk
@@ -71,7 +71,7 @@ void test_adfFileTruncateGetBlocksToRemove ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = // tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     const unsigned file_blocks_used_by_empty_file = 1;
@@ -155,7 +155,7 @@ void test_adfFileTruncateGetBlocksToRemove ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( device, 0, FALSE );
+        adfMount ( device, 0, ADF_ACCESS_MODE_READWRITE );
 
     file = adfFileOpen ( vol, filename, ADF_FILE_MODE_READ );
     ck_assert_ptr_nonnull ( file );
@@ -340,7 +340,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);

--- a/tests/test_file_write.c
+++ b/tests/test_file_write.c
@@ -46,7 +46,7 @@ void test_file_write ( test_data_t * const tdata )
 
     // mount the test volume
     struct AdfVolume * vol = // tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     ck_assert_ptr_nonnull ( vol );
 
     // check it is an empty floppy disk
@@ -68,7 +68,7 @@ void test_file_write ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = // tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     const unsigned file_blocks_used_by_empty_file = 1;
@@ -151,7 +151,7 @@ void test_file_write ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     //ck_assert_int_eq ( free_blocks_before - file_blocks_used_by_empty_file - 1,
@@ -320,7 +320,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);

--- a/tests/test_file_write_chunks.c
+++ b/tests/test_file_write_chunks.c
@@ -47,7 +47,7 @@ void test_file_write ( test_data_t * const tdata )
 
     // mount the test volume
     struct AdfVolume * vol = // tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     ck_assert_ptr_nonnull ( vol );
 
     // check it is an empty floppy disk
@@ -69,7 +69,7 @@ void test_file_write ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = // tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     const unsigned file_blocks_used_by_empty_file = 1;
@@ -180,7 +180,7 @@ void test_file_write ( test_data_t * const tdata )
     // reset volume state (remount)
     adfUnMount ( vol );
     vol = //tdata->vol =
-        adfMount ( tdata->device, 0, FALSE );
+        adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
 
     // verify free blocks
     //ck_assert_int_eq ( free_blocks_before - file_blocks_used_by_empty_file - 1,
@@ -377,7 +377,7 @@ void setup ( test_data_t * const tdata )
         exit(1);
     }
 
-    //tdata->vol = adfMount ( tdata->device, 0, FALSE );
+    //tdata->vol = adfMount ( tdata->device, 0, ADF_ACCESS_MODE_READWRITE );
     //if ( ! tdata->vol )
     //    return;
     //    exit(1);


### PR DESCRIPTION
This was started in consequence of #63, and discussed further in #64.

The new code in the update does what's in the title - it rebuilds the block allocation bitmap when mounting a volume, if the bitmap is marked as "invalid".
There is also a new command-line utility, which allows to display and to enforce rebuilding the bitmap.

While this resolves #63, there is still one thing to consider: 2. from #64 (but that is to further improve the reliability).

There are some new tests (in `regtests/`) that works as follows:
- the test take the images from `regtests/Dumps/` makes a copy, rebuilds the bitmap and compares it to the original (here some surprises - some of the images created with old ADFlib seem not valid(!), see exceptions in the script `regtests/Test/bitmap_recreate.sh`)

This means that any image copied to `regtests/Dumps/` will be checked by the test - so anyone can use the test with any adf image. I have done this on many images and the rebuilt bitmap was always identical (with the exceptions mentioned earlier...). It is not really feasible to add to the repo many more dumps for testing...

So - the code seems to work fine. But, of course, more tests are welcomed, if anyone is willing to do so.
