### PR TITLE
Fixed some compilation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,12 @@ if ( NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" )
     )
 endif()
 
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
+    message ( STATUS "Setting additional clang options/checks" )
+    add_compile_options (
+      -Wno-gnu-statement-expression-from-macro-expansion
+    )
+endif()
 
 option ( ADFLIB_ENABLE_ADDRESS_SANITIZER "Enable address sanitizer" OFF )
 

--- a/examples/adf_bitmap.c
+++ b/examples/adf_bitmap.c
@@ -174,7 +174,7 @@ int show_block_allocation_bitmap ( struct AdfVolume * const vol )
 
     printf ( "\nBlock allocation bitmap valid:    %s\n",
              rb.bmFlag == BM_VALID ? "yes" : "No!" );
-    
+
     /* Check root bm pages  */
     unsigned nerrors = 0,
         nblocks_free = 0,
@@ -288,7 +288,7 @@ int show_block_allocation_bitmap ( struct AdfVolume * const vol )
                 "(or bitmap ext.) blocks could not be read\n"
                 " so the numbers above are not fully accurate "
                 "(exclude data from the unchecked bitmap blocks!)\n", nerrors );
-    return ( nerrors > 0 ) ? 1 : 0;    
+    return ( nerrors > 0 ) ? 1 : 0;
 }
 
 

--- a/examples/adf_bitmap.c
+++ b/examples/adf_bitmap.c
@@ -53,8 +53,10 @@ int main ( int     argc,
         command = COMMAND_REBUILD;
     else if ( strcmp ( argv[1], "show" ) == 0 )
         command = COMMAND_SHOW;
-    else if ( strcmp ( argv[1], "help" ) == 0 )
+    else if ( strcmp ( argv[1], "help" ) == 0 ) {
         usage();
+        return 0;
+    }
     else {
         fprintf ( stderr, "\nUnknown command '%s'  "
                   "(use 'adf_bitmap help' for usage info)\n\n",

--- a/examples/adf_bitmap.c
+++ b/examples/adf_bitmap.c
@@ -223,7 +223,6 @@ int show_block_allocation_bitmap ( struct AdfVolume * const vol )
 
     /* show bmExt blocks */
     SECTNUM bmExtBlkPtr = rb.bmExt;
-    unsigned bmExt_i = 0;
     while ( bmExtBlkPtr != 0 ) {
         struct bBitmapExtBlock bmExtBlk;
         RETCODE rc = adfReadBitmapExtBlock ( vol, bmExtBlkPtr, &bmExtBlk );
@@ -275,7 +274,6 @@ int show_block_allocation_bitmap ( struct AdfVolume * const vol )
         }
 
         bmExtBlkPtr = bmExtBlk.nextBlock;
-        bmExt_i++;
     }
 
     /* show block statistics */

--- a/examples/adf_show_metadata_volume.c
+++ b/examples/adf_show_metadata_volume.c
@@ -28,10 +28,10 @@ void show_volume_metadata ( struct AdfVolume * const vol )
     show_bootblock ( &bblock, false );
 
     struct bRootBlock rblock;
-    uint32_t root_block_sector = adfVolCalcRootBlk ( vol );
+    SECTNUM root_block_sector = adfVolCalcRootBlk ( vol );
     printf ("\nRoot block sector:\t%u\n", root_block_sector );
 
-    if ( adfReadRootBlock ( vol, root_block_sector, &rblock ) != RC_OK ) {
+    if ( adfReadRootBlock ( vol, (uint32_t)root_block_sector, &rblock ) != RC_OK ) {
         fprintf ( stderr, "Error reading rootblock at sector %u.\n", root_block_sector );
         return;
     }

--- a/examples/adf_show_metadata_volume.c
+++ b/examples/adf_show_metadata_volume.c
@@ -24,7 +24,7 @@ void show_volume_metadata ( struct AdfVolume * const vol )
     if ( adfReadBootBlock ( vol, &bblock ) != RC_OK ) {
         fprintf ( stderr, "Error reading rootblock\n");
         return;
-    }    
+    }
     show_bootblock ( &bblock, false );
 
     struct bRootBlock rblock;

--- a/examples/unadf.c
+++ b/examples/unadf.c
@@ -67,7 +67,7 @@ struct AdfList *file_list = NULL;
 
 /* prototypes */
 void parse_args(int argc, char *argv[]);
-void help();
+void help(void);
 void print_device(struct AdfDevice *dev);
 void print_volume(struct AdfVolume * vol);
 void print_tree(struct AdfList *node, char *path);
@@ -227,7 +227,7 @@ void parse_args(int argc, char *argv[]) {
     }
 }
 
-void help() {
+void help(void) {
     fprintf(stderr,
         "unadf [-lrcsmpw] [-v n] [-d extractdir] dumpname.adf [files-with-path]\n"
         "    -l : lists root directory contents\n"

--- a/src/adf_cache.c
+++ b/src/adf_cache.c
@@ -23,7 +23,7 @@
  *  along with Foobar; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
- */ 
+ */
 
 #include "adf_cache.h"
 
@@ -103,7 +103,7 @@ struct AdfList * adfGetDirEntCache ( struct AdfVolume * const vol,
             }
             entry->size = (uint32_t) caEntry.size;
             entry->access = (int32_t) caEntry.protect;
-            adfDays2Date( caEntry.days, &(entry->year), &(entry->month), 
+            adfDays2Date( caEntry.days, &(entry->year), &(entry->month),
                 &(entry->days) );
             entry->hour = caEntry.mins/60;
             entry->mins = caEntry.mins%60;
@@ -111,9 +111,9 @@ struct AdfList * adfGetDirEntCache ( struct AdfVolume * const vol,
 
             /* add it into the linked list */
             if (head==NULL)
-                head = cell = newCell(NULL, (void*)entry); 
+                head = cell = newCell(NULL, (void*)entry);
             else
-                cell = newCell(cell, (void*)entry); 
+                cell = newCell(cell, (void*)entry);
 
             if (cell==NULL) {
                 adfFreeEntry(entry);
@@ -128,8 +128,8 @@ struct AdfList * adfGetDirEntCache ( struct AdfVolume * const vol,
         }
         nSect = dirc.nextDirC;
     }while (nSect!=0);
-    
-    return head;	
+
+    return head;
 }
 
 
@@ -193,7 +193,7 @@ RETCODE adfGetCacheEntry ( const struct bDirCacheBlock * const dirc,
 /*printf("cEntry->nLen %d cEntry->cLen %d %s\n",cEntry->nLen,cEntry->cLen,cEntry->name);*/
     *p  = ptr+24+cEntry->nLen+1+cEntry->cLen;
 
-    /* the starting offset of each record must be even (68000 constraint) */ 
+    /* the starting offset of each record must be even (68000 constraint) */
     if ((*p%2)!=0)
         *p=(*p)+1;
 
@@ -247,7 +247,7 @@ int adfPutCacheEntry ( struct bDirCacheBlock * const       dirc,
         return l+1;
     }
 
-    /* ptr%2 must be == 0, if l%2==0, (ptr+l)%2==0 */ 
+    /* ptr%2 must be == 0, if l%2==0, (ptr+l)%2==0 */
 }
 
 
@@ -348,8 +348,8 @@ RETCODE adfDelFromCache ( struct AdfVolume * const         vol,
                         return rc;
                 }
                 else {
-                    /* dirc.recordsNb ==1 or == 0 , prevSect!=-1 : 
-                    * the only record in this dirc block and a previous dirc block exists 
+                    /* dirc.recordsNb ==1 or == 0 , prevSect!=-1 :
+                    * the only record in this dirc block and a previous dirc block exists
                     */
                     adfSetBlockFree(vol, dirc.headerKey);
 
@@ -399,7 +399,7 @@ RETCODE adfAddInCache ( struct AdfVolume * const  vol,
     entryLen = adfEntry2CacheEntry(entry, &newEntry);
 /*printf("adfAddInCache--%4ld %2d %6ld %8lx %4d %2d:%02d:%02d %30s %22s\n",
     newEntry.header, newEntry.type, newEntry.size, newEntry.protect,
-    newEntry.days, newEntry.mins/60, newEntry.mins%60, 
+    newEntry.days, newEntry.mins/60, newEntry.mins%60,
 	newEntry.ticks/50,
 	newEntry.name, newEntry.comm);
 */
@@ -418,13 +418,13 @@ RETCODE adfAddInCache ( struct AdfVolume * const  vol,
 
 /*printf("*%4ld %2d %6ld %8lx %4d %2d:%02d:%02d %30s %22s\n",
     caEntry.header, caEntry.type, caEntry.size, caEntry.protect,
-    caEntry.days, caEntry.mins/60, caEntry.mins%60, 
+    caEntry.days, caEntry.mins/60, caEntry.mins%60,
 	caEntry.ticks/50,
 	caEntry.name, caEntry.comm);
 */
             n++;
         }
-        
+
 /*        if (offset+entryLen<=488) {
             adfPutCacheEntry(&dirc, &offset, &newEntry);
             dirc.recordsNb++;
@@ -528,8 +528,8 @@ RETCODE adfUpdateCache ( struct AdfVolume * const   vol,
                 }
                 else if (oLen>nLen) {
 /*puts("oLen>nLen");*/
-                    /* the new record is shorter, write it, 
-                     * then shift down the following records 
+                    /* the new record is shorter, write it,
+                     * then shift down the following records
                      */
                     adfPutCacheEntry(&dirc, &oldOffset, &newEntry);
                     for(i=oldOffset+nLen; i<(488-sLen); i++)
@@ -605,7 +605,7 @@ RETCODE adfCreateEmptyCache ( struct AdfVolume * const   vol,
         (*adfEnv.wFct)("adfCreateEmptyCache : unknown secType");
 /*printf("secType=%ld\n",parent->secType);*/
     }
-        
+
     dirc.recordsNb = 0;
     dirc.nextDirC = 0;
 
@@ -655,9 +655,9 @@ RETCODE adfWriteDirCBlock ( struct AdfVolume * const      vol,
 {
     uint8_t buf[LOGICAL_BLOCK_SIZE];
     uint32_t newSum;
- 
+
     dirc->type = T_DIRC;
-    dirc->headerKey = nSect; 
+    dirc->headerKey = nSect;
 
     memcpy(buf, dirc, LOGICAL_BLOCK_SIZE);
 #ifdef LITT_ENDIAN

--- a/src/adf_cache.c
+++ b/src/adf_cache.c
@@ -229,7 +229,7 @@ int adfPutCacheEntry ( struct bDirCacheBlock * const       dirc,
     memcpy(dirc->records+ptr+18,&(cEntry->mins),2);
     memcpy(dirc->records+ptr+20,&(cEntry->ticks),2);
 #endif
-    dirc->records[ptr+22] =(signed char)cEntry->type;
+    dirc->records[ptr+22] =(uint8_t)cEntry->type;
 
     dirc->records[ptr+23] = cEntry->nLen;
     memcpy(dirc->records+ptr+24, cEntry->name, cEntry->nLen);

--- a/src/adf_env.c
+++ b/src/adf_env.c
@@ -60,7 +60,7 @@ static void checkInternals(void);
  * adfInitEnv
  *
  */
-void adfEnvInitDefault()
+void adfEnvInitDefault(void)
 {
     checkInternals();
 
@@ -91,7 +91,7 @@ void adfEnvInitDefault()
  * adfEnvCleanUp
  *
  */
-void adfEnvCleanUp()
+void adfEnvCleanUp(void)
 {
     free(adfEnv.nativeFct);
 }
@@ -168,7 +168,7 @@ void adfSetEnvFct ( const AdfLogFct    eFct,
  * adfGetVersionNumber
  *
  */
-char* adfGetVersionNumber()
+char* adfGetVersionNumber(void)
 {
 	return(ADFLIB_VERSION);
 }
@@ -178,7 +178,7 @@ char* adfGetVersionNumber()
  * adfGetVersionDate
  *
  */
-char* adfGetVersionDate()
+char* adfGetVersionDate(void)
 {
 	return(ADFLIB_DATE);
 }

--- a/src/adf_env.c
+++ b/src/adf_env.c
@@ -71,7 +71,7 @@ void adfEnvInitDefault()
     adfEnv.notifyFct = Changed;
     adfEnv.rwhAccess = rwHeadAccess;
     adfEnv.progressBar = progressBar;
-	
+
     adfEnv.useDirCache = FALSE;
     adfEnv.useRWAccess = FALSE;
     adfEnv.useNotify = FALSE;

--- a/src/adf_env.h
+++ b/src/adf_env.h
@@ -70,17 +70,17 @@ struct AdfEnv {
 };
 
 
-PREFIX void adfEnvInitDefault();
+PREFIX void adfEnvInitDefault(void);
 
 PREFIX void adfSetEnvFct ( const AdfLogFct    eFct,
                            const AdfLogFct    wFct,
                            const AdfLogFct    vFct,
                            const AdfNotifyFct notifyFct );
 
-PREFIX void adfEnvCleanUp();
+PREFIX void adfEnvCleanUp(void);
 PREFIX void adfChgEnvProp(int prop, void *new);
-PREFIX char* adfGetVersionNumber();
-PREFIX char* adfGetVersionDate();
+PREFIX char* adfGetVersionNumber(void);
+PREFIX char* adfGetVersionDate(void);
 
 PREFIX extern struct AdfEnv adfEnv;
 

--- a/src/adf_env.h
+++ b/src/adf_env.h
@@ -7,7 +7,7 @@
  *  adf_env.h
  *
  *  $Id$
- *  
+ *
  *  This file is part of ADFLib.
  *
  *  ADFLib is free software; you can redistribute it and/or modify

--- a/src/adf_file.c
+++ b/src/adf_file.c
@@ -115,14 +115,18 @@ RETCODE adfFileTruncateGetBlocksToRemove ( const struct AdfFile * const file,
 #endif
 
     unsigned blocksCount = 0;
+#ifdef DEBUG_ADF_FILE
     unsigned dataBlocksCount = 0;
+#endif
     if ( nExtBlocksOld < 1 ) {
         // no ext. blocks (neither in orig. or truncated)
         int32_t * const dataBlocks = file->fileHdr->dataBlocks;
         for ( unsigned i = nDBlocksNew + 1 ; i <= nDBlocksOld ; ++i ) {
             assert ( blocksCount < nBlocksToRemove );
             blocksToRemove->sectors [ blocksCount++ ] = dataBlocks [ MAX_DATABLK - i ];
+#ifdef DEBUG_ADF_FILE
             dataBlocksCount++;
+#endif
         }
     } else {
         // the file to truncate has at least one ext. block
@@ -142,7 +146,9 @@ RETCODE adfFileTruncateGetBlocksToRemove ( const struct AdfFile * const file,
             for ( unsigned i = nDBlocksNew + 1 ; i <= MAX_DATABLK ; ++i ) {
                 assert ( blocksCount < nBlocksToRemove );
                 blocksToRemove->sectors [ blocksCount++ ] = dataBlocks [ MAX_DATABLK - i ];
+#ifdef DEBUG_ADF_FILE
                 dataBlocksCount++;
+#endif
             }
             nextExt = (unsigned) file->fileHdr->extension;
         }
@@ -183,7 +189,9 @@ RETCODE adfFileTruncateGetBlocksToRemove ( const struct AdfFile * const file,
                 for ( unsigned i = firstDBlockToRemove ; i <= lastDBlockToRemove ; ++i ) {
                     assert ( blocksCount < nBlocksToRemove );
                     blocksToRemove->sectors [ blocksCount++ ] = dataBlocks [ MAX_DATABLK - i ];
+#ifdef DEBUG_ADF_FILE
                     dataBlocksCount++;
+#endif
                 }
             }
 
@@ -217,13 +225,17 @@ RETCODE adfFileTruncateGetBlocksToRemove ( const struct AdfFile * const file,
                 SECTNUM dblock = dataBlocks [ MAX_DATABLK - i ];
                 if ( dblock > 0 ) {
                     blocksToRemove->sectors [ blocksCount++ ] = dblock;
+#ifdef DEBUG_ADF_FILE
                     dataBlocksCount++;
+#endif
                 }
             }*/
             for ( unsigned i = 1 ; i <= lastDBlockToRemove ; ++i ) {
                 assert ( dataBlocks [ MAX_DATABLK - i ] > 0 );
                 blocksToRemove->sectors [ blocksCount++ ] = dataBlocks [ MAX_DATABLK - i ];
+#ifdef DEBUG_ADF_FILE
                 dataBlocksCount++;
+#endif
             }
 
             // add currently loaded ext. to remove

--- a/src/adf_file.c
+++ b/src/adf_file.c
@@ -685,7 +685,7 @@ RETCODE adfFileSeek ( struct AdfFile * const file,
 /*
  * adfFileOpen
  *
- */ 
+ */
 struct AdfFile * adfFileOpen ( struct AdfVolume * const vol,
                                const char * const       name,
                                const AdfFileMode        mode )
@@ -848,10 +848,10 @@ void adfFileClose ( struct AdfFile * file )
 
     if (file->currentExt)
         free(file->currentExt);
-    
+
     if (file->currentData)
         free(file->currentData);
-    
+
     free(file->fileHdr);
     free(file);
 
@@ -1167,7 +1167,7 @@ RETCODE adfFileCreateNextBlock ( struct AdfFile * const file )
         nSect = adfGet1FreeBlock(file->volume);
         if ( nSect == -1 )
             return RC_VOLFULL;
-        
+
 /*printf("adfCreateNextFileBlock ext %ld\n",nSect);*/
 
         file->currentExt->dataBlocks[MAX_DATABLK-1-file->posInExtBlk] = nSect;
@@ -1198,7 +1198,7 @@ RETCODE adfFileCreateNextBlock ( struct AdfFile * const file )
 /*printf ("writedata=%d\n",file->curDataPtr);*/
             memset(file->currentData,0,512);
         }
-            
+
 /*printf("datablk=%d\n",nSect);*/
     file->curDataPtr = nSect;
     file->nDataBlock++;

--- a/src/adf_link.c
+++ b/src/adf_link.c
@@ -24,11 +24,6 @@
  */
 
 
-#if defined (__ANY_IDEA_WHAT_IS_THIS_FOR__)
-// the code below is not used anywhere and seems unfinished
-// (not clear what it was meant for...)
-// -> disabling it for now
-
 #include<string.h>
 
 #include"adf_str.h"
@@ -36,6 +31,11 @@
 #include"adf_dir.h"
 #include "adf_env.h"
 
+
+#if defined (__ANY_IDEA_WHAT_IS_THIS_FOR__)
+// the code below is not used anywhere and seems unfinished
+// (not clear what it was meant for...)
+// -> disabling it for now
 
 /*
  *

--- a/src/adf_nativ.h
+++ b/src/adf_nativ.h
@@ -52,7 +52,7 @@ struct AdfNativeFunctions {
     BOOL (*adfIsDevNative)( const char * const devName );
 };
 
-void adfInitNativeFct();
+void adfInitNativeFct( void );
 
 #endif /* ADF_NATIV_H */
 

--- a/src/adf_util.h
+++ b/src/adf_util.h
@@ -38,7 +38,7 @@ struct DateTime {
 
 /* defines max and min */
 #ifndef max
-#if !defined(__clang__) && defined(__GNUC__)
+#if defined(__clang__) || defined(__GNUC__)
 #define max(a,b)             \
 ({                           \
     __typeof__ (a) _a = (a); \
@@ -51,7 +51,7 @@ struct DateTime {
 #endif
 
 #ifndef min
-#if !defined(__clang__) && defined(__GNUC__)
+#if defined(__clang__) || defined(__GNUC__)
 #define min(a,b)             \
 ({                           \
     __typeof__ (a) _a = (a); \

--- a/src/adf_util.h
+++ b/src/adf_util.h
@@ -38,7 +38,7 @@ struct DateTime {
 
 /* defines max and min */
 #ifndef max
-#if defined(__clang__) || defined(__GNUC__)
+#if !defined(__clang__) && defined(__GNUC__)
 #define max(a,b)             \
 ({                           \
     __typeof__ (a) _a = (a); \
@@ -51,7 +51,7 @@ struct DateTime {
 #endif
 
 #ifndef min
-#if defined(__clang__) || defined(__GNUC__)
+#if !defined(__clang__) && defined(__GNUC__)
 #define min(a,b)             \
 ({                           \
     __typeof__ (a) _a = (a); \

--- a/src/generic/adf_nativ.c
+++ b/src/generic/adf_nativ.c
@@ -96,7 +96,7 @@ BOOL myIsDevNative ( const char * const devName )
  * adfInitNativeFct
  *
  */
-void adfInitNativeFct()
+void adfInitNativeFct( void )
 {
     struct AdfNativeFunctions * nFct =
         ( struct AdfNativeFunctions * ) adfEnv.nativeFct;

--- a/src/generic/adf_nativ.c
+++ b/src/generic/adf_nativ.c
@@ -89,6 +89,9 @@ RETCODE myReleaseDevice ( struct AdfDevice * const dev )
  */
 BOOL myIsDevNative ( const char * const devName )
 {
+    /* Quiet unused parameter warning */
+    (void)(devName);
+
     return FALSE;
 }
 


### PR DESCRIPTION
Most of this should be harmless.

The fix in `add_bitmap.c` should be vetted though. I believe the intention here is to return after displaying the usage info but I could be mistaken.