### PR TITLE
adfFileWrite: update dataSize when extending an OFS block.

### DIFF
--- a/src/adf_file.c
+++ b/src/adf_file.c
@@ -1092,6 +1092,12 @@ uint32_t adfFileWrite ( struct AdfFile * const file,
         file->posInDataBlk += size;
         file->currentDataBlockChanged = true;
 
+        if ( adfVolIsOFS ( file->volume ) ) {
+            struct AdfOFSDataBlock *ofsData =
+                (struct AdfOFSDataBlock *) file->currentData;
+            ofsData->dataSize = max ( ofsData->dataSize, file->posInDataBlk );
+        }
+
         // update file size in the header
         file->fileHdr->byteSize = max ( file->fileHdr->byteSize,
                                         file->pos );


### PR DESCRIPTION
When appending data to an existing OFS block, the dataSize field in the block header wasn't being extended. So if you wrote a file via fuseadf, 4Kb at a time, then the first 4Kb write would terminate in mid-block leaving that block's dataSize indicating that it was half full; then the second 4Kb write would write the first part of its data into the partial block but leave that block's dataSize field unchanged. An emulated Workbench 1.3 era Amiga would honour the dataSize field and treat the partial block as short, losing the initial segment of the second 4Kb of the source file.